### PR TITLE
Polish mass ingest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# IntelliJ
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM eclipse-temurin:8-focal AS jdk8
-FROM eclipse-temurin:11-focal AS jdk11
-FROM eclipse-temurin:17-focal AS jdk17
+FROM eclipse-temurin:8-jammy AS jdk8
+FROM eclipse-temurin:11-jammy AS jdk11
+FROM eclipse-temurin:17-jammy AS jdk17
 
 # Install dependencies for `mod` cli
 FROM jdk17 AS dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN java -jar mod.jar config moderne edit --token=${MODERNE_TOKEN} https://${MOD
 RUN java -jar mod.jar config lsts artifacts artifactory edit ${PUBLISH_URL} --user ${PUBLISH_USER} --password ${PUBLISH_PASSWORD}
 
 # Configure Maven Settings if they are required to build
-ADD ~/.m2/settings.xml /root/.m2/settings.xml
+ADD maven/settings.xml /root/.m2/settings.xml
 RUN java -jar mod.jar config build maven settings edit /root/.m2/settings.xml
 
 # Configure git credentials if they are required to clone

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ https://sambsnyd:likescats@github.com
 If your organization **does not** use the Maven build tool, comment out the [following lines](/Dockerfile#L30-L31):
 
 ```Dockerfile
-ADD ~/.m2/settings.xml /root/.m2/settings.xml
+ADD maven/settings.xml /root/.m2/settings.xml
 RUN java -jar mod.jar config build maven settings edit /root/.m2/settings.xml
 ```
 

--- a/maven/settings.xml
+++ b/maven/settings.xml
@@ -1,0 +1,28 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <localRepository/>
+    <interactiveMode/>
+    <offline/>
+    <pluginGroups/>
+    <servers/>
+    <mirrors/>
+    <proxies/>
+    <profiles>
+        <profile>
+            <id>oss-snapshots</id>
+            <repositories>
+                <repository>
+                    <id>oss-sonatype-mirror</id>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>oss-snapshots</activeProfile>
+    </activeProfiles>
+</settings>


### PR DESCRIPTION
There is no Java 21 focal image; focal refers to Ubuntu 20.04
Better then to already switch to jammy, which is Ubuntu 22.04
Then in April we can switch to noble for Ubuntu 24.04

```
tim@tim-xps-15-9520:~$ docker pull eclipse-temurin:21-focal
Error response from daemon: manifest for eclipse-temurin:21-focal not found: manifest unknown: manifest unknown
tim@tim-xps-15-9520:~$ docker pull eclipse-temurin:21-jammy
21-jammy: Pulling from library/eclipse-temurin
Digest: sha256:4280c36ff5cab08aa53600154899de7ee3ae885a59253cf94dc901c37546ca41
Status: Image is up to date for eclipse-temurin:21-jammy
docker.io/library/eclipse-temurin:21-jammy
```

Also: we tried to use `ADD ~/.m2/settings.xml /root/.m2/settings.xml`, but `~` is outside the Docker context; figured easier for folks to have an example file added under `maven/settings.xml`.