### PR TITLE
Fix PowerShell partition skipping to match bash behavior

### DIFF
--- a/publish.ps1
+++ b/publish.ps1
@@ -52,12 +52,6 @@ function Invoke-BuildAndUploadRepos {
 
     mod git clone csv .\$PartitionName $File --filter=tree:0
 
-    # if cloning failed, skip the rest of the loop
-    if (-not $?) {
-      Write-Host "[$Index][${PartitionName}] Cloning failed, skipping partition"
-      continue
-    }
-
     mod build .\$PartitionName --no-download
 
     mod publish .\$PartitionName


### PR DESCRIPTION
Remove error checking that skips entire partitions when clone fails.
This aligns PowerShell behavior with bash script which continues
processing successfully cloned repositories even if some fail.
