### PR TITLE
Fix PowerShell error handling to match bash script

### DIFF
--- a/publish.ps1
+++ b/publish.ps1
@@ -4,7 +4,7 @@ Param(
   [string]$CsvFile
 )
 
-$ErrorActionPreference="Stop" # abort on errors
+$ErrorActionPreference="Continue" # continue on errors to match bash behavior
 
 # Clean any existing files in the data directory
 if (Test-Path -Path $env:DATA_DIR) {


### PR DESCRIPTION
Change ErrorActionPreference from 'Stop' to 'Continue' to align with bash
script behavior where errors don't abort the entire process. This matches
the bash script's commented out 'set -o errexit' approach.
