### PR TITLE
Add minimal mass-ingest deployment example

### DIFF
--- a/minimal-example/.env.example
+++ b/minimal-example/.env.example
@@ -1,0 +1,7 @@
+# Required: Artifact repository for publishing LSTs
+PUBLISH_URL=<artifact-repository-url>
+PUBLISH_USER=<username>
+PUBLISH_PASSWORD=<password>
+
+# Optional: Load repos.csv from remote URL
+# REPOS_CSV_URL=https://example.com/repos.csv

--- a/minimal-example/Dockerfile
+++ b/minimal-example/Dockerfile
@@ -1,0 +1,36 @@
+FROM eclipse-temurin:21-jdk-noble
+
+RUN apt-get update && apt-get install -y \
+    git \
+    git-lfs \
+    jq \
+    curl \
+    && git lfs install \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG PUBLISH_URL
+ARG PUBLISH_USER
+ARG PUBLISH_PASSWORD
+
+WORKDIR /usr/local/bin
+
+COPY moderne-cli-*.jar mod.jar
+
+RUN echo '#!/bin/sh' > mod && \
+    echo 'java -jar /usr/local/bin/mod.jar "$@"' >> mod && \
+    chmod +x mod
+
+WORKDIR /app
+
+RUN mod config lsts artifacts maven edit ${PUBLISH_URL} --user ${PUBLISH_USER} --password ${PUBLISH_PASSWORD};
+
+EXPOSE 8080
+
+ENV CUSTOM_CI=true
+ENV DATA_DIR=/var/moderne
+
+COPY --chmod=755 publish.sh publish.sh
+COPY repos.csv repos.csv
+
+CMD ["./publish.sh", "repos.csv"]

--- a/minimal-example/README.md
+++ b/minimal-example/README.md
@@ -1,0 +1,204 @@
+# Moderne mass-ingest deployment
+
+## Quick start
+
+1. Download the Moderne CLI:
+```bash
+# Check https://github.com/moderneinc/moderne-cli/releases/latest for the latest stable release
+# Replace VERSION with the actual version number (e.g., 3.26.5)
+curl -o moderne-cli.jar https://repo1.maven.org/maven2/io/moderne/moderne-cli/VERSION/moderne-cli-VERSION.jar
+```
+
+2. Configure environment variables:
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set:
+- `PUBLISH_URL`
+- `PUBLISH_USER`
+- `PUBLISH_PASSWORD`
+
+3. Start the mass-ingest service:
+```bash
+docker compose up -d
+```
+
+4. Monitor metrics:
+```bash
+curl http://localhost:8080/prometheus
+```
+
+## Architecture
+
+The deployment runs a single container that:
+1. Downloads repos.csv (if `REPOS_CSV_URL` is set)
+2. Starts `mod monitor` in the background on port 8080
+3. Clones, builds, and publishes LSTs from repositories
+4. Uploads build logs to artifact repository
+5. Stops monitoring and exits
+
+The script runs once and exits. For continuous ingestion, configure your container orchestrator to restart the container on a schedule.
+
+## Endpoints
+
+- Port `8080` - Prometheus metrics endpoint (`/prometheus`)
+
+## Health monitoring
+
+Mass-ingest runs as a batch job that executes once and exits. Unlike long-running services, it does not provide health probe endpoints (liveness, readiness, startup).
+
+Monitor the ingestion process using the metrics endpoint while the container is running:
+```bash
+curl http://localhost:8080/prometheus
+```
+
+The container is configured with `restart: unless-stopped` in docker-compose.yml, so it will automatically restart and process repositories again after completion.
+
+## Build tool requirements
+
+### JDK versions
+
+The minimal Dockerfile includes JDK 21 only. If your projects require other JDK versions (8, 11, 17, 25), extend the Dockerfile to install them. See the [full example](https://github.com/moderneinc/mass-ingest-example) for multi-JDK installation.
+
+### Maven and Gradle
+
+The minimal setup assumes Maven and Gradle wrappers (`mvnw`, `gradlew`) are checked into repositories. If wrappers are not present, install Maven and/or Gradle in the Dockerfile. See the [full example](https://github.com/moderneinc/mass-ingest-example) for installation instructions.
+
+## Repository configuration
+
+### Local repos.csv
+
+Edit `repos.csv` to specify repositories to ingest:
+
+```csv
+cloneUrl,branch,origin,path,org1,org2,org3
+https://github.com/org/repo,main,github.com,org/repo,Team,Department,ALL
+```
+
+Required columns: `cloneUrl`, `branch`, `origin`, `path`
+Optional columns: `org1`, `org2` ... `orgN` (organizational hierarchy)
+
+### Remote repos.csv
+
+Load repos.csv from an HTTP(S) URL by setting the `REPOS_CSV_URL` environment variable:
+
+```bash
+REPOS_CSV_URL=https://example.com/repos.csv
+```
+
+Add to `.env` file or pass as environment variable in docker-compose. If set, the container will download repos.csv from the URL at startup.
+
+## Scaling
+
+### Manual partitioning with --start/--end
+
+Scale ingestion by running multiple containers that process different ranges of repositories using `--start` and `--end` parameters:
+
+```yaml
+services:
+  mass-ingest-1:
+    build:
+      context: .
+      args:
+        PUBLISH_URL: ${PUBLISH_URL}
+        PUBLISH_USER: ${PUBLISH_USER}
+        PUBLISH_PASSWORD: ${PUBLISH_PASSWORD}
+    command: ./publish.sh repos.csv --start 1 --end 100
+    ports:
+      - "8081:8080"
+    volumes:
+      - data-1:/var/moderne
+    restart: unless-stopped
+
+  mass-ingest-2:
+    build:
+      context: .
+      args:
+        PUBLISH_URL: ${PUBLISH_URL}
+        PUBLISH_USER: ${PUBLISH_USER}
+        PUBLISH_PASSWORD: ${PUBLISH_PASSWORD}
+    command: ./publish.sh repos.csv --start 101 --end 200
+    ports:
+      - "8082:8080"
+    volumes:
+      - data-2:/var/moderne
+    restart: unless-stopped
+
+volumes:
+  data-1:
+  data-2:
+```
+
+Each container processes its assigned range of repository lines (excluding the header).
+
+### Remote partition files
+
+Alternatively, use remote URLs for different partition files:
+
+```yaml
+services:
+  mass-ingest-1:
+    build:
+      context: .
+      args:
+        PUBLISH_URL: ${PUBLISH_URL}
+        PUBLISH_USER: ${PUBLISH_USER}
+        PUBLISH_PASSWORD: ${PUBLISH_PASSWORD}
+    environment:
+      - REPOS_CSV_URL=https://example.com/repos-partition-1.csv
+    ports:
+      - "8081:8080"
+    volumes:
+      - data-1:/var/moderne
+
+  mass-ingest-2:
+    build:
+      context: .
+      args:
+        PUBLISH_URL: ${PUBLISH_URL}
+        PUBLISH_USER: ${PUBLISH_USER}
+        PUBLISH_PASSWORD: ${PUBLISH_PASSWORD}
+    environment:
+      - REPOS_CSV_URL=https://example.com/repos-partition-2.csv
+    ports:
+      - "8082:8080"
+    volumes:
+      - data-2:/var/moderne
+
+volumes:
+  data-1:
+  data-2:
+```
+
+## Build timeout
+
+Builds are automatically terminated after 45 minutes to prevent indefinitely hanging builds.
+
+## Storage requirements
+
+The `data` volume stores cloned repositories and build artifacts:
+- Minimum: 32 GB
+- 1000+ repositories: 64-128 GB recommended
+
+## Configuration reference
+
+### Build arguments
+
+Required:
+- `PUBLISH_URL` - Artifact repository URL for LST publishing
+- `PUBLISH_USER` - Artifact repository username
+- `PUBLISH_PASSWORD` - Artifact repository password
+
+### Runtime requirements
+
+- Minimum per container: 2 CPU cores, 16 GB RAM, 32 GB storage
+- JDK: JDK 21 included, install additional versions if needed
+- Build tools: Maven/Gradle wrappers must be checked into repositories
+- Git authentication: Configure `.git-credentials` or SSH keys if repositories require authentication
+
+### Environment variables
+
+- `REPOS_CSV_URL` - Optional URL to download repos.csv at startup
+- `DATA_DIR` - Data directory (defaults to `/var/moderne`)
+- `CUSTOM_CI` - Disables extra formatting in logs (set automatically)

--- a/minimal-example/docker-compose.yml
+++ b/minimal-example/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  mass-ingest:
+    build:
+      context: .
+      args:
+        PUBLISH_URL: ${PUBLISH_URL}
+        PUBLISH_USER: ${PUBLISH_USER}
+        PUBLISH_PASSWORD: ${PUBLISH_PASSWORD}
+    ports:
+      - "8080:8080"
+    environment:
+      - REPOS_CSV_URL=${REPOS_CSV_URL:-}
+    volumes:
+      - data:/var/moderne
+    restart: unless-stopped
+
+volumes:
+  data:

--- a/minimal-example/publish.sh
+++ b/minimal-example/publish.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+
+if [ -n "${REPOS_CSV_URL:-}" ]; then
+    echo "Downloading repos.csv from ${REPOS_CSV_URL}"
+    curl -f -o repos.csv "${REPOS_CSV_URL}"
+fi
+
+if [ $# -eq 0 ]; then
+    echo "No repository file supplied. Please provide the path to the csv file."
+    exit 1
+fi
+
+MONITOR_PID="monitor.pid"
+SOURCE_CSV=""
+START_INDEX=""
+END_INDEX=""
+
+export NO_COLOR=1
+
+info() {
+    if [[ -n "$START_INDEX" && -n "$END_INDEX" ]]; then
+        printf "[%d-%d] %s\n" "$START_INDEX" "$END_INDEX" "$1"
+    else
+        printf "%s\n" "$1"
+    fi
+}
+
+die() {
+    if [[ -n "$START_INDEX" && -n "$END_INDEX" ]]; then
+        printf "[%d-%d] %s\n" "$START_INDEX" "$END_INDEX" "$1" >&2
+    else
+        printf "%s\n" "$1" >&2
+    fi
+    exit 1
+}
+
+main() {
+    SOURCE_CSV=$1
+    shift
+
+    while [[ $# -ne 0 ]]; do
+        arg="$1"
+        case "$arg" in
+            --end)
+                END_INDEX="$2"
+                ;;
+            --start)
+                START_INDEX="$2"
+                ;;
+            *)
+                die "Invalid option: $arg"
+                ;;
+        esac
+        shift 2
+    done
+
+    ingest_repos
+}
+
+ingest_repos() {
+    prepare_environment
+    start_monitoring
+    select_repositories "$SOURCE_CSV"
+
+    partition_name=$(date +"%Y-%m-%d-%H-%M")
+
+    if ! build_and_upload_repos "$partition_name" "$DATA_DIR/selected-repos.csv"; then
+        info "Error building and uploading repositories"
+    else
+        info "Successfully built and uploaded repositories"
+    fi
+
+    send_logs
+    stop_monitoring
+}
+
+prepare_environment() {
+    info "Preparing environment"
+    mkdir -p "$DATA_DIR"
+    rm -rf "${DATA_DIR:?}"/*
+    mkdir -p "$HOME/.moderne/cli/metrics/"
+    rm -rf "$HOME/.moderne/cli/metrics"/*
+}
+
+start_monitoring() {
+    info "Starting monitoring"
+    nohup mod monitor --port 8080 > /dev/null 2>&1 &
+    echo $! > "$DATA_DIR/$MONITOR_PID"
+}
+
+stop_monitoring() {
+    info "Cleaning up monitoring"
+    if [ -f "$DATA_DIR/$MONITOR_PID" ]; then
+        kill -9 $(cat "$DATA_DIR/$MONITOR_PID") 2>/dev/null || true
+        rm "$DATA_DIR/$MONITOR_PID"
+    fi
+}
+
+select_repositories() {
+    local csv_file=$1
+
+    if [ ! -f "$csv_file" ]; then
+        die "File $csv_file does not exist"
+    fi
+
+    if [[ -n "$START_INDEX" && -n "$END_INDEX" ]]; then
+        info "Selecting repositories from $csv_file starting at $START_INDEX and ending at $END_INDEX"
+
+        header=$(head -n 1 "$csv_file")
+        selected_lines=$(tail -n +2 "$csv_file" | sed -n "${START_INDEX},${END_INDEX}p")
+
+        ( echo "$header"; echo "$selected_lines" ) > "$DATA_DIR/selected-repos.csv"
+    else
+        info "Selected all repositories from $csv_file"
+        cp "$csv_file" "$DATA_DIR/selected-repos.csv"
+    fi
+}
+
+build_and_upload_repos() {
+    local clone_dir="$DATA_DIR/$1"
+    local partition_file=$2
+    info "Building and uploading repositories into $clone_dir from $partition_file"
+
+    export NO_COLOR=true
+    export TERM=dumb
+
+    mod git sync csv "$clone_dir" "$partition_file" --with-sources
+
+    timeout 2700 mod build "$clone_dir" --no-download
+    ret=$?
+    if [ $ret -eq 124 ]; then
+        printf "\n* Build timed out after 45 minutes\n\n"
+    fi
+
+    mod publish "$clone_dir"
+    mod log builds add "$clone_dir" "$DATA_DIR/log.zip" --last-build
+    return $ret
+}
+
+send_logs() {
+    local index_label
+    if [[ -n "$START_INDEX" && -n "$END_INDEX" ]]; then
+        index_label="$START_INDEX-$END_INDEX"
+    else
+        index_label="full"
+    fi
+
+    local timestamp=$(date +"%Y%m%d%H%M")
+
+    if [[ -n "$PUBLISH_USER" && -n "$PUBLISH_PASSWORD" ]]; then
+        logs_url=$PUBLISH_URL/io/moderne/ingest-log/$index_label/$timestamp/ingest-log-cli-$timestamp-$index_label.zip
+        info "Uploading logs to $logs_url"
+        if ! curl -s -S --insecure -u "$PUBLISH_USER":"$PUBLISH_PASSWORD" -X PUT "$logs_url" -T "$DATA_DIR/log.zip"; then
+            info "Failed to publish logs"
+        fi
+    else
+        info "No log publishing credentials provided"
+    fi
+}
+
+main "$@"

--- a/minimal-example/repos.csv
+++ b/minimal-example/repos.csv
@@ -1,0 +1,12 @@
+cloneUrl,branch,origin,path
+https://github.com/openrewrite/rewrite-cucumber-jvm,main,github.com,openrewrite/rewrite-cucumber-jvm
+https://github.com/openrewrite/rewrite-hibernate,main,github.com,openrewrite/rewrite-hibernate
+https://github.com/openrewrite/rewrite-javascript,main,github.com,openrewrite/rewrite-javascript
+https://github.com/openrewrite/rewrite-launchdarkly,main,github.com,openrewrite/rewrite-launchdarkly
+https://github.com/openrewrite/rewrite-liberty,main,github.com,openrewrite/rewrite-liberty
+https://github.com/openrewrite/rewrite-maven-plugin,main,github.com,openrewrite/rewrite-maven-plugin
+https://github.com/openrewrite/rewrite-micrometer,main,github.com,openrewrite/rewrite-micrometer
+https://github.com/openrewrite/rewrite-micronaut,main,github.com,openrewrite/rewrite-micronaut
+https://github.com/openrewrite/rewrite-okhttp,main,github.com,openrewrite/rewrite-okhttp
+https://github.com/openrewrite/rewrite-recipe-bom,main,github.com,openrewrite/rewrite-recipe-bom
+https://github.com/openrewrite/rewrite-recommendations,main,github.com,openrewrite/rewrite-recommendations


### PR DESCRIPTION
## Problem

Customers need a clean, minimal deployment example for mass-ingest that demonstrates:
- Minimal Dockerfile with strict minimum dependencies
- Prometheus integration instructions
- Remote repos.csv loading
- Storage requirements
- Scaling approaches

## Solution

Added `minimal-example` directory containing production-ready example:

- Minimal Dockerfile (JDK 21 only, extensible)
- Integrated monitoring with Prometheus metrics endpoint (`/prometheus`)
- Remote repos.csv loading support
- Scaling examples (--start/--end partitioning and remote partition files)
- Storage requirements documented