### PR TITLE
Make AWS CLI optional in Dockerfile to reduce image size

### DIFF
--- a/3-scalability/README.md
+++ b/3-scalability/README.md
@@ -53,6 +53,9 @@ Required columns:
 
 ### 2. Build and push Docker image
 
+> [!NOTE]
+> **For S3 repos.csv support:** If using `s3://` URLs for your repos.csv (e.g., `ingest_csv_file = "s3://bucket/repos.csv"`), uncomment the AWS CLI installation section in the Dockerfile before building. This adds ~300MB to the image. HTTP/HTTPS repos.csv URLs work without AWS CLI.
+
 ```bash
 # Build the image from repository root
 docker build -t mass-ingest:latest ..

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,13 @@ COPY --from=jdk17 /opt/java/openjdk /usr/lib/jvm/temurin-17-jdk
 COPY --from=jdk21 /opt/java/openjdk /usr/lib/jvm/temurin-21-jdk
 COPY --from=jdk25 /opt/java/openjdk /usr/lib/jvm/temurin-25-jdk
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-    unzip awscliv2.zip && \
-    ./aws/install
+# UNCOMMENT FOR 3-scalability: Install AWS CLI for S3 repos.csv support (~300MB)
+# Required if using S3 URLs for repos.csv in AWS Batch deployments
+# Also useful for 2-observability if fetching repos.csv from S3
+# RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+#     unzip awscliv2.zip && \
+#     ./aws/install && \
+#     rm -rf awscliv2.zip aws
 
 FROM dependencies AS modcli
 ARG MODERNE_CLI_STAGE=stable


### PR DESCRIPTION
## Problem

AWS CLI was being installed by default in the Dockerfile, adding ~300MB to every image regardless of whether S3 support was actually needed.

For stages 1 (quickstart) and 2 (observability), users typically work with local repos.csv files and don't need S3 support. This unnecessary bloat increases:
- Build times
- Image storage costs  
- Pull times for users

## Solution

Comment out AWS CLI installation by default. Users who need S3 support (primarily stage 3/AWS Batch) can easily uncomment 5 lines.

**Changes:**
- Comment out AWS CLI in Dockerfile (~300MB savings)
- Add clear instructions about when to enable it
- Document in 3-scalability README that AWS CLI is only needed for S3 URLs
- Note that HTTP/HTTPS repos.csv URLs work without AWS CLI

## Benefits

- **Minimal images by default** - only includes infrastructure needed by all users
- **Opt-in for advanced features** - S3 support available when needed
- **Clear documentation** - users know exactly when/why to enable it
- **Faster builds** - no AWS CLI download/install for most users