### PR TITLE
Add multiple Gradle version support and register installations with CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,9 +108,23 @@ RUN mkdir -p /root/.moderne/cli/dist && \
 FROM modcli AS language-support
 
 # Gradle (comment if projects don't use Gradle without a wrapper)
-RUN wget --no-check-certificate https://services.gradle.org/distributions/gradle-8.14-bin.zip
-RUN mkdir /opt/gradle
-RUN unzip -d /opt/gradle gradle-8.14-bin.zip
+# Install one or more Gradle versions for repos that lack a Gradle wrapper.
+# Add additional versions as needed (e.g., for repos whose build scripts require older Gradle).
+RUN wget --no-check-certificate https://services.gradle.org/distributions/gradle-8.14-bin.zip && \
+    mkdir -p /opt/gradle && \
+    unzip -d /opt/gradle gradle-8.14-bin.zip && \
+    rm gradle-8.14-bin.zip
+
+# UNCOMMENT to install additional Gradle versions for repos that need them.
+# Then use the `gradleVersion` column in repos.csv to select which version to use per repo.
+# RUN wget --no-check-certificate https://services.gradle.org/distributions/gradle-6.9.4-bin.zip && \
+#     unzip -d /opt/gradle gradle-6.9.4-bin.zip && \
+#     rm gradle-6.9.4-bin.zip
+
+# Register all Gradle installations so the CLI can select the right version per repo.
+# List all /opt/gradle/* directories here. If you installed additional versions above, add them.
+RUN mod config build gradle installation edit /opt/gradle/gradle-8.14
+# RUN mod config build gradle installation edit /opt/gradle/gradle-8.14 /opt/gradle/gradle-6.9.4
 ENV PATH="${PATH}:/opt/gradle/gradle-8.14/bin"
 
 # Maven (comment if projects don't use Maven without a wrapper)

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,23 +109,23 @@ FROM modcli AS language-support
 
 # Gradle (comment if projects don't use Gradle without a wrapper)
 # Install one or more Gradle versions for repos that lack a Gradle wrapper.
-# Add additional versions as needed (e.g., for repos whose build scripts require older Gradle).
-RUN wget --no-check-certificate https://services.gradle.org/distributions/gradle-8.14-bin.zip && \
-    mkdir -p /opt/gradle && \
-    unzip -d /opt/gradle gradle-8.14-bin.zip && \
-    rm gradle-8.14-bin.zip
-
-# UNCOMMENT to install additional Gradle versions for repos that need them.
+# To add versions for repos with older build scripts, add them to GRADLE_EXTRA_VERSIONS (comma-separated).
 # Then use the `gradleVersion` column in repos.csv to select which version to use per repo.
-# RUN wget --no-check-certificate https://services.gradle.org/distributions/gradle-6.9.4-bin.zip && \
-#     unzip -d /opt/gradle gradle-6.9.4-bin.zip && \
-#     rm gradle-6.9.4-bin.zip
+ARG GRADLE_VERSION=8.14
+ARG GRADLE_EXTRA_VERSIONS=
+RUN mkdir -p /opt/gradle && \
+    wget --no-check-certificate https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip && \
+    unzip -d /opt/gradle gradle-${GRADLE_VERSION}-bin.zip && \
+    rm gradle-${GRADLE_VERSION}-bin.zip && \
+    for v in $(echo "${GRADLE_EXTRA_VERSIONS}" | tr ',' ' '); do \
+        wget --no-check-certificate https://services.gradle.org/distributions/gradle-${v}-bin.zip && \
+        unzip -d /opt/gradle gradle-${v}-bin.zip && \
+        rm gradle-${v}-bin.zip; \
+    done
 
 # Register all Gradle installations so the CLI can select the right version per repo.
-# List all /opt/gradle/* directories here. If you installed additional versions above, add them.
-RUN mod config build gradle installation edit /opt/gradle/gradle-8.14
-# RUN mod config build gradle installation edit /opt/gradle/gradle-8.14 /opt/gradle/gradle-6.9.4
-ENV PATH="${PATH}:/opt/gradle/gradle-8.14/bin"
+RUN mod config build gradle installation edit $(find /opt/gradle -maxdepth 1 -mindepth 1 -type d | sort -V)
+ENV PATH="${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin"
 
 # Maven (comment if projects don't use Maven without a wrapper)
 # NOTE: This version may be out of date as new versions are continually released. Check here for the latest version: https://repo1.maven.org/maven2/org/apache/maven/apache-maven/

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -88,13 +88,14 @@ RUN CLI_VERSION="${MODERNE_CLI_VERSION}"; \
     fi
 
 # Download Gradle (comment if projects don't use Gradle without a wrapper)
-# Download one or more Gradle versions for repos that lack a Gradle wrapper.
-# Add additional versions as needed (e.g., for repos whose build scripts require older Gradle).
+# To add versions for repos with older build scripts, add them to GRADLE_EXTRA_VERSIONS (comma-separated).
+# Then use the `gradleVersion` column in repos.csv to select which version to use per repo.
 ARG GRADLE_VERSION=8.14
-RUN curl -fsSL -o /tmp/gradle-${GRADLE_VERSION}-bin.zip "${GRADLE_DIST_URL}/gradle-${GRADLE_VERSION}-bin.zip"
-# UNCOMMENT to download additional Gradle versions:
-# ARG GRADLE_VERSION_2=6.9.4
-# RUN curl -fsSL -o /tmp/gradle-${GRADLE_VERSION_2}-bin.zip "${GRADLE_DIST_URL}/gradle-${GRADLE_VERSION_2}-bin.zip"
+ARG GRADLE_EXTRA_VERSIONS=
+RUN curl -fsSL -o /tmp/gradle-${GRADLE_VERSION}-bin.zip "${GRADLE_DIST_URL}/gradle-${GRADLE_VERSION}-bin.zip" && \
+    for v in $(echo "${GRADLE_EXTRA_VERSIONS}" | tr ',' ' '); do \
+        curl -fsSL -o /tmp/gradle-${v}-bin.zip "${GRADLE_DIST_URL}/gradle-${v}-bin.zip"; \
+    done
 
 # Download Maven (comment if projects don't use Maven without a wrapper)
 # NOTE: Check for latest version: https://repo1.maven.org/maven2/org/apache/maven/apache-maven/
@@ -236,21 +237,18 @@ RUN mkdir -p /root/.moderne/cli/dist && \
 
 # Gradle (comment if projects don't use Gradle without a wrapper)
 ARG GRADLE_VERSION=8.14
-COPY --from=downloader /tmp/gradle-${GRADLE_VERSION}-bin.zip gradle-${GRADLE_VERSION}-bin.zip
+ARG GRADLE_EXTRA_VERSIONS=
+COPY --from=downloader /tmp/gradle-*.zip /tmp/
 RUN mkdir -p /opt/gradle && \
-    unzip -d /opt/gradle gradle-${GRADLE_VERSION}-bin.zip && \
-    rm gradle-${GRADLE_VERSION}-bin.zip
-
-# UNCOMMENT to install additional Gradle versions for repos that need them.
-# Then use the `gradleVersion` column in repos.csv to select which version to use per repo.
-# ARG GRADLE_VERSION_2=6.9.4
-# COPY --from=downloader /tmp/gradle-${GRADLE_VERSION_2}-bin.zip gradle-${GRADLE_VERSION_2}-bin.zip
-# RUN unzip -d /opt/gradle gradle-${GRADLE_VERSION_2}-bin.zip && rm gradle-${GRADLE_VERSION_2}-bin.zip
+    unzip -d /opt/gradle /tmp/gradle-${GRADLE_VERSION}-bin.zip && \
+    rm /tmp/gradle-${GRADLE_VERSION}-bin.zip && \
+    for v in $(echo "${GRADLE_EXTRA_VERSIONS}" | tr ',' ' '); do \
+        unzip -d /opt/gradle /tmp/gradle-${v}-bin.zip && \
+        rm /tmp/gradle-${v}-bin.zip; \
+    done
 
 # Register all Gradle installations so the CLI can select the right version per repo.
-# List all /opt/gradle/* directories here. If you installed additional versions above, add them.
-RUN mod config build gradle installation edit /opt/gradle/gradle-${GRADLE_VERSION}
-# RUN mod config build gradle installation edit /opt/gradle/gradle-${GRADLE_VERSION} /opt/gradle/gradle-${GRADLE_VERSION_2}
+RUN mod config build gradle installation edit $(find /opt/gradle -maxdepth 1 -mindepth 1 -type d | sort -V)
 ENV PATH="${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin"
 
 # Maven (comment if projects don't use Maven without a wrapper)

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -88,8 +88,13 @@ RUN CLI_VERSION="${MODERNE_CLI_VERSION}"; \
     fi
 
 # Download Gradle (comment if projects don't use Gradle without a wrapper)
+# Download one or more Gradle versions for repos that lack a Gradle wrapper.
+# Add additional versions as needed (e.g., for repos whose build scripts require older Gradle).
 ARG GRADLE_VERSION=8.14
 RUN curl -fsSL -o /tmp/gradle-${GRADLE_VERSION}-bin.zip "${GRADLE_DIST_URL}/gradle-${GRADLE_VERSION}-bin.zip"
+# UNCOMMENT to download additional Gradle versions:
+# ARG GRADLE_VERSION_2=6.9.4
+# RUN curl -fsSL -o /tmp/gradle-${GRADLE_VERSION_2}-bin.zip "${GRADLE_DIST_URL}/gradle-${GRADLE_VERSION_2}-bin.zip"
 
 # Download Maven (comment if projects don't use Maven without a wrapper)
 # NOTE: Check for latest version: https://repo1.maven.org/maven2/org/apache/maven/apache-maven/
@@ -232,8 +237,20 @@ RUN mkdir -p /root/.moderne/cli/dist && \
 # Gradle (comment if projects don't use Gradle without a wrapper)
 ARG GRADLE_VERSION=8.14
 COPY --from=downloader /tmp/gradle-${GRADLE_VERSION}-bin.zip gradle-${GRADLE_VERSION}-bin.zip
-RUN mkdir /opt/gradle
-RUN unzip -d /opt/gradle gradle-${GRADLE_VERSION}-bin.zip && rm gradle-${GRADLE_VERSION}-bin.zip
+RUN mkdir -p /opt/gradle && \
+    unzip -d /opt/gradle gradle-${GRADLE_VERSION}-bin.zip && \
+    rm gradle-${GRADLE_VERSION}-bin.zip
+
+# UNCOMMENT to install additional Gradle versions for repos that need them.
+# Then use the `gradleVersion` column in repos.csv to select which version to use per repo.
+# ARG GRADLE_VERSION_2=6.9.4
+# COPY --from=downloader /tmp/gradle-${GRADLE_VERSION_2}-bin.zip gradle-${GRADLE_VERSION_2}-bin.zip
+# RUN unzip -d /opt/gradle gradle-${GRADLE_VERSION_2}-bin.zip && rm gradle-${GRADLE_VERSION_2}-bin.zip
+
+# Register all Gradle installations so the CLI can select the right version per repo.
+# List all /opt/gradle/* directories here. If you installed additional versions above, add them.
+RUN mod config build gradle installation edit /opt/gradle/gradle-${GRADLE_VERSION}
+# RUN mod config build gradle installation edit /opt/gradle/gradle-${GRADLE_VERSION} /opt/gradle/gradle-${GRADLE_VERSION_2}
 ENV PATH="${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin"
 
 # Maven (comment if projects don't use Maven without a wrapper)

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ The `repos.csv` file columns:
 - `origin` (required) - Source identifier (e.g., `github.com`)
 - `path` (required) - Repository path/identifier
 - `branch` (optional) - Branch to build (uses remote default if not specified)
+- `gradleVersion` (optional) - Selects a specific Gradle version for repos without a wrapper (must match an installation registered via `mod config build gradle installation edit`)
 
 See [repos.csv documentation](https://docs.moderne.io/user-documentation/moderne-cli/references/repos-csv) for advanced options.
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,8 @@ docker build -f Dockerfile.fips -t mass-ingest:fips .
 |----------------------|----------------------------------------------|----------------------------------------|
 | `MAVEN_REPO_URL`    | `https://repo1.maven.org/maven2`             | Maven repository for CLI and Maven     |
 | `GRADLE_DIST_URL`   | `https://services.gradle.org/distributions`  | Gradle distribution download URL       |
-| `GRADLE_VERSION`    | `8.14`                                       | Gradle version to install              |
+| `GRADLE_VERSION`    | `8.14`                                       | Primary Gradle version to install      |
+| `GRADLE_EXTRA_VERSIONS` | *(empty)*                                | Comma-separated additional Gradle versions (e.g., `6.9.4,5.6.4`) |
 | `MAVEN_VERSION`     | `3.9.11`                                     | Maven version to install               |
 
 **Using internal mirrors:**


### PR DESCRIPTION
## Background / problem

- The Moderne CLI added support for multiple non-wrapper Gradle installations in [moderneinc/moderne-cli#3565](https://github.com/moderneinc/moderne-cli/pull/3565) (released in CLI 4.0.9). This lets customers use the `gradleVersion` column in `repos.csv` to select a specific Gradle version per repo, which is needed when repos lack a Gradle wrapper and the system Gradle is too new for the build script (e.g., `archiveName()` removed in Gradle 7).

The mass ingest Dockerfiles didn't take advantage of this yet -- they installed a single Gradle version and didn't register it with `mod config build gradle installation edit`.

## Solution

Updated both `Dockerfile` and `Dockerfile.fips` to register the installed Gradle with `mod config build gradle installation edit`, and added commented examples showing how to install and register additional Gradle versions. Also documented the `gradleVersion` column in the README's repos.csv section.

## Test plan
- [x] Build Docker image with single Gradle version (default) and verify `mod config build gradle installation list` shows it
- [x] Uncomment second Gradle version, rebuild, and verify both appear in `mod config build gradle installation list`