### PR TITLE
Add AWS CodeArtifact support to the mass-ingest examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,16 @@ PUBLISH_PASSWORD=your-password
 # Note: On EC2 with IAM roles, Docker adds a network hop, so you must set the
 # IMDSv2 hop limit to 2. See 1-quickstart/README.md for details.
 
+# Option D: AWS CodeArtifact (Maven repo with a short-lived, rotating auth token)
+# The token is minted and refreshed at runtime; do not set PUBLISH_USER/PASSWORD.
+# Authenticate via an IAM role (Batch/ECS/EC2) rather than static keys when possible.
+# Requires the AWS CLI and CodeArtifact build wiring in the Dockerfile (see README).
+# PUBLISH_URL=https://my-domain-111122223333.d.codeartifact.us-east-1.amazonaws.com/maven/my-repo/
+# CODEARTIFACT_DOMAIN=my-domain
+# CODEARTIFACT_DOMAIN_OWNER=111122223333                 # AWS account ID that owns the domain
+# CODEARTIFACT_REGION=us-east-1                           # Region of the domain
+# CODEARTIFACT_TOKEN_DURATION=43200                       # Optional: token lifetime in seconds (default 12h)
+
 # ==============================================================================
 # SCM CREDENTIALS (Required for private repositories)
 # ==============================================================================

--- a/Dockerfile
+++ b/Dockerfile
@@ -328,7 +328,7 @@ RUN git config --global credential.helper "store --file=/root/.git-credentials"
 ################################################################################
 # Publish LSTs to and resolve build dependencies from AWS CodeArtifact.
 # CodeArtifact tokens are short-lived (max 12h), so publish.sh mints and refreshes
-# them at runtime; only the build wiring below is baked into the image.
+# them at runtime; only the build configuration below is baked into the image.
 #
 # 1. Uncomment the AWS CLI install block above (required to mint tokens).
 # 2. Uncomment the lines below for the build tool(s) your repositories use.

--- a/Dockerfile
+++ b/Dockerfile
@@ -310,14 +310,44 @@ RUN git config --global credential.helper "store --file=/root/.git-credentials"
 # AWS CLI for S3 repos.csv support (~300MB)
 # Uncomment when using S3 URLs for repos.csv in AWS Batch deployments.
 # Also useful for 2-observability if fetching repos.csv from S3.
-# HTTP/HTTPS URLs work without this. Comment out if not needed:
-#RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+# Required for AWS CodeArtifact (publish.sh uses it to mint auth tokens).
+# HTTP/HTTPS URLs work without this. Comment out if not needed.
+# $(uname -m) resolves to x86_64 or aarch64 for the image's target platform (RUN steps
+# execute on the target platform, including under `docker buildx --platform`), so
+# Graviton/arm64 images get the right AWS CLI build automatically.
+#RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
 #    unzip awscliv2.zip && \
 #    ./aws/install
 
 # Chunk script for AWS Batch parallel processing
 # Uncomment to include the chunk.sh script for 3-scalability:
 # COPY --chmod=755 3-scalability/chunk.sh chunk.sh
+
+################################################################################
+# OPTIONAL: AWS CodeArtifact (Maven repository with rotating auth token)
+################################################################################
+# Publish LSTs to and resolve build dependencies from AWS CodeArtifact.
+# CodeArtifact tokens are short-lived (max 12h), so publish.sh mints and refreshes
+# them at runtime; only the build wiring below is baked into the image.
+#
+# 1. Uncomment the AWS CLI install block above (required to mint tokens).
+# 2. Uncomment the lines below for the build tool(s) your repositories use.
+# See the "Using AWS CodeArtifact" section in README.md for the runtime env vars.
+
+# Maven dependency resolution via CodeArtifact (token read from ${env.CODEARTIFACT_AUTH_TOKEN}).
+# Only the COPY happens at build time; publish.sh registers the file with
+# `mod config build maven settings edit` at runtime, and only when CodeArtifact is
+# selected — its catch-all mirror would otherwise break Maven builds in non-CodeArtifact
+# runs of this image. If you also use the "Custom Maven Settings" section above, merge
+# the mirror/server into that settings.xml instead of uncommenting this COPY; publish.sh
+# leaves an existing /root/.m2/settings.xml configuration untouched.
+# COPY maven/settings-codeartifact.xml /app/maven/settings-codeartifact.xml
+
+# Gradle dependency/plugin resolution via CodeArtifact (token read from ${CODEARTIFACT_AUTH_TOKEN}).
+# Note: `gradle arguments edit` replaces any previously configured Gradle arguments, so
+# list them all (the init script plus any others your repositories need) in one command:
+# COPY gradle/init-codeartifact.gradle /app/gradle/init-codeartifact.gradle
+# RUN mod config build gradle arguments edit --init-script=/app/gradle/init-codeartifact.gradle
 
 ################################################################################
 # FINAL SETUP

--- a/README.md
+++ b/README.md
@@ -292,13 +292,20 @@ RHEL 9 backported TLS 1.3 into JDK 8 and 11, but the backported `P11AEADCipher` 
 
 ## Using AWS CodeArtifact
 
-AWS CodeArtifact is a standard Basic-auth Maven repository, but its password is a short-lived token (minted with `aws codeartifact get-authorization-token`, expires within 12h), not a static secret. The examples handle this by minting the token at runtime and refreshing it before every batch, so a long-running or scheduled ingest never goes stale. The same token is reused for dependency resolution during the build.
+AWS CodeArtifact is a standard Basic-auth Maven repository, but its password is a short-lived token (minted with `aws codeartifact get-authorization-token`, expires within 12h), not a static secret. The examples handle this by minting the token at runtime and refreshing it before every batch, so a long-running or scheduled ingest never goes stale. The same token is reused for dependency resolution during the build. After each publish, the uploaded package versions are finalized to `Published` status: CodeArtifact marks versions uploaded without a `maven-metadata.xml` as `Unfinished` and its Maven endpoint returns 404 for them, which would otherwise make the LSTs and the `repos-lock.csv` catalog invisible to the Moderne platform.
 
 ### Authentication
 
 Authenticate with an IAM role attached to the compute (AWS Batch job role, ECS task role, or EC2 instance profile) rather than static access keys. The AWS CLI in the container picks up the role automatically. If you must use static keys, pass them as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables.
 
-The IAM principal needs `codeartifact:GetAuthorizationToken`, `codeartifact:ReadFromRepository`, `codeartifact:PublishPackageVersion`, `codeartifact:PutPackageMetadata`, and `sts:GetServiceBearerToken`.
+The IAM principal needs
+* `codeartifact:GetAuthorizationToken`
+* `codeartifact:ListPackageVersions`
+* `codeartifact:PublishPackageVersion`
+* `codeartifact:PutPackageMetadata`
+* `codeartifact:ReadFromRepository`
+* `codeartifact:UpdatePackageVersionsStatus`
+* `sts:GetServiceBearerToken`
 
 ### Image setup
 
@@ -307,9 +314,19 @@ In the `Dockerfile`, uncomment the AWS CLI install block, then uncomment the lin
 - Maven: `COPY maven/settings-codeartifact.xml /app/maven/settings-codeartifact.xml` (publish.sh registers it at runtime, only when CodeArtifact is selected, so the same image still builds Maven projects in S3/Artifactory runs)
 - Gradle: `COPY gradle/init-codeartifact.gradle /app/gradle/init-codeartifact.gradle` (+ the `mod config build gradle arguments edit` line; the init script no-ops when CodeArtifact is not in use)
 
-Gradle ignores `settings.xml` for credentials, so it needs the init script; Maven needs the settings file. Wire every build tool your portfolio uses: an un-wired tool silently resolves dependencies from public repositories instead of CodeArtifact. Both read the rotating token from the environment at build time. If you set `CODEARTIFACT_DOMAIN` but wire neither tool, publish.sh logs a warning. If you use the "Custom Maven Settings" Dockerfile section, merge the CodeArtifact `<server>`/`<mirror>` into your own settings.xml instead; publish.sh leaves an existing `/root/.m2/settings.xml` configuration untouched.
+Gradle ignores `settings.xml` for credentials, so it needs the init script; Maven needs the settings file. Configure CodeArtifact for every build tool your portfolio uses — an unconfigured tool cannot reach CodeArtifact and resolves entirely from public repositories. If you set `CODEARTIFACT_DOMAIN` but configure neither tool, publish.sh logs a warning.
 
-For a wired tool, the catch-all `<mirror>` in `settings-codeartifact.xml` (and the Gradle repository) routes that tool's dependency resolution through CodeArtifact, so the domain must have an upstream connection for every external repository your builds need (e.g. Maven Central, Gradle Plugin Portal). Narrow the `<mirrorOf>` if you want only some repositories proxied.
+### Dependency resolution
+
+Both tools resolve only what CodeArtifact serves: `PUBLISH_URL` plus its upstream chain. Public repositories need an external connection, which must come from CodeArtifact's fixed, AWS-managed list (Maven Central, Google Android, Gradle Plugin Portal, CommonsWare, Clojars) — you cannot proxy an arbitrary remote (e.g. Sonatype snapshots) as you would in Nexus or Artifactory. Internal artifacts already in the domain resolve through the upstream chain with the same token; a different domain or account is out of reach, since the token is domain-scoped.
+
+#### Maven
+
+publish.sh registers `settings-codeartifact.xml` only on a CodeArtifact run, so the same image still builds S3/Artifactory runs. It ships with a catch-all mirror (`<mirrorOf>*</mirrorOf>`), so all Maven resolution goes through CodeArtifact and anything it cannot reach fails the build; narrow the `<mirrorOf>` to let those repositories resolve from their original source instead. A `/root/.m2/settings.xml` you supply yourself is left untouched — merge the `<server>`/`<mirror>` in.
+
+#### Gradle
+
+The init script adds CodeArtifact as an additional repository, so resolution stays additive: a Gradle build keeps its own repositories and falls back to them, and is correspondingly not forced through CodeArtifact. To isolate a Gradle build to CodeArtifact, remove the other repositories from the project.
 
 ### Environment variables
 
@@ -325,9 +342,9 @@ Do not set `PUBLISH_USER`/`PUBLISH_PASSWORD` for CodeArtifact; the script authen
 
 ### Known limitations
 
-- **Organization catalog updates fail after the first publish.** After publishing LSTs, `mod publish` maintains a central catalog CSV (`repos-lock.csv`) at a fixed Maven coordinate by downloading, merging, and re-uploading it. CodeArtifact package assets are immutable (re-publishing the same asset with different content returns HTTP 409), so from the second publish onward `mod publish` reports `Failed to update central effective repos-lock.csv` and the catalog stays at its first-publish contents. The LST JARs themselves publish at unique coordinates and are unaffected, but if your Moderne tenant reads its organization structure from this catalog (`moderne.organization.sources.*`), repos from later batches or runs will not appear in it until CodeArtifact supports overwriting the asset or the CLI handles it natively. Workaround: delete the `repos-lock` package version in CodeArtifact (`aws codeartifact delete-package-versions`) before a re-ingest so the first publish of the run recreates the catalog; note that in a batched run only that first publish succeeds in writing it, so a complete catalog requires an unbatched or org-mode run.
+- **Only the first publish updates the organization catalog.** `mod publish` maintains the `repos-lock.csv` catalog at a fixed coordinate by re-uploading it, but CodeArtifact assets are immutable, so every publish after the first returns HTTP 409 and the catalog keeps only the first publish's repos. LST JARs use unique coordinates and are unaffected. If your tenant reads its org structure from this catalog (`moderne.organization.sources.*`), do a single unbatched or org-mode run, and delete the `repos-lock` version (`aws codeartifact delete-package-versions`) before re-ingesting.
 - **Build logs are not stored in CodeArtifact.** Its Maven endpoint rejects non-Maven log artifact paths, so publish.sh skips the log upload (the logs remain in the local `log.zip`/`syncs.zip`).
-- **Package versions show as "Unfinished" in the CodeArtifact console.** The CLI uploads artifacts directly without a `maven-metadata.xml`, which CodeArtifact uses to mark versions "Published". Unfinished versions are excluded from version listings but remain downloadable at their direct URLs, which is how the platform consumes them.
+- **The platform must read the published catalog directly, not poll the repository.** CodeArtifact provides neither a Maven Indexer index nor an Artifactory-style query API, so the connector cannot discover LSTs by polling it. The tenant's artifact source must be configured without a `poll:` block ("lock mode"), so it reads the `repos-lock.csv` this ingest publishes.
 - This CodeArtifact path is implemented in `publish.sh` (bash) only; the PowerShell `publish.ps1` entrypoint does not include it.
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ All stages share the same core configuration needs:
 - `MODERNE_TENANT` - Your Moderne tenant url (optional)
 - `MODERNE_TOKEN` - Moderne API token (optional)
 
+For AWS CodeArtifact, set `CODEARTIFACT_DOMAIN` (and `PUBLISH_URL` to the CodeArtifact Maven endpoint) instead of `PUBLISH_USER`/`PUBLISH_PASSWORD`. See [Using AWS CodeArtifact](#using-aws-codeartifact).
+
 ### Repository authentication
 
 For private repositories, credentials are mounted at runtime (never baked into images):
@@ -287,6 +289,60 @@ RHEL 9 backported TLS 1.3 into JDK 8 and 11, but the backported `P11AEADCipher` 
 
 > [!NOTE]
 > For full kernel-level FIPS compliance, the host OS must also be running in FIPS mode. The container enforces FIPS-approved algorithms at the userspace level (OpenSSL, Java security providers) regardless of host configuration.
+
+## Using AWS CodeArtifact
+
+AWS CodeArtifact is a standard Basic-auth Maven repository, but its password is a short-lived token (minted with `aws codeartifact get-authorization-token`, expires within 12h), not a static secret. The examples handle this by minting the token at runtime and refreshing it before every batch, so a long-running or scheduled ingest never goes stale. The same token is reused for dependency resolution during the build.
+
+### Authentication
+
+Authenticate with an IAM role attached to the compute (AWS Batch job role, ECS task role, or EC2 instance profile) rather than static access keys. The AWS CLI in the container picks up the role automatically. If you must use static keys, pass them as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables.
+
+The IAM principal needs `codeartifact:GetAuthorizationToken`, `codeartifact:ReadFromRepository`, `codeartifact:PublishPackageVersion`, `codeartifact:PutPackageMetadata`, and `sts:GetServiceBearerToken`.
+
+### Image setup
+
+In the `Dockerfile`, uncomment the AWS CLI install block, then uncomment the lines in the "OPTIONAL: AWS CodeArtifact" section for the build tool(s) your repositories use:
+
+- Maven: `COPY maven/settings-codeartifact.xml /app/maven/settings-codeartifact.xml` (publish.sh registers it at runtime, only when CodeArtifact is selected, so the same image still builds Maven projects in S3/Artifactory runs)
+- Gradle: `COPY gradle/init-codeartifact.gradle /app/gradle/init-codeartifact.gradle` (+ the `mod config build gradle arguments edit` line; the init script no-ops when CodeArtifact is not in use)
+
+Gradle ignores `settings.xml` for credentials, so it needs the init script; Maven needs the settings file. Wire every build tool your portfolio uses: an un-wired tool silently resolves dependencies from public repositories instead of CodeArtifact. Both read the rotating token from the environment at build time. If you set `CODEARTIFACT_DOMAIN` but wire neither tool, publish.sh logs a warning. If you use the "Custom Maven Settings" Dockerfile section, merge the CodeArtifact `<server>`/`<mirror>` into your own settings.xml instead; publish.sh leaves an existing `/root/.m2/settings.xml` configuration untouched.
+
+For a wired tool, the catch-all `<mirror>` in `settings-codeartifact.xml` (and the Gradle repository) routes that tool's dependency resolution through CodeArtifact, so the domain must have an upstream connection for every external repository your builds need (e.g. Maven Central, Gradle Plugin Portal). Narrow the `<mirrorOf>` if you want only some repositories proxied.
+
+### Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `PUBLISH_URL` | yes | CodeArtifact Maven HTTPS endpoint, e.g. `https://my-domain-111122223333.d.codeartifact.us-east-1.amazonaws.com/maven/my-repo/` |
+| `CODEARTIFACT_DOMAIN` | yes | CodeArtifact domain name. Setting this selects the CodeArtifact path. |
+| `CODEARTIFACT_DOMAIN_OWNER` | optional | AWS account ID that owns the domain. Derived from `PUBLISH_URL` when unset; set it explicitly if your endpoint host does not follow the standard format. |
+| `CODEARTIFACT_REGION` | optional | AWS region of the domain. Derived from `PUBLISH_URL` when unset. |
+| `CODEARTIFACT_TOKEN_DURATION` | optional | Token lifetime in seconds (default 12h; `0` ties it to the role session, which can be shorter than 12h under a capped assumed-role session). |
+
+Do not set `PUBLISH_USER`/`PUBLISH_PASSWORD` for CodeArtifact; the script authenticates the publish target with `aws` and the current token directly. Set `BATCH_SIZE` so each batch completes inside the token lifetime: the token is refreshed once per batch, so an unbatched run (the default) or org mode (`-o`) mints it only once and a build/publish that runs past the expiry will fail.
+
+### Known limitations
+
+- **Organization catalog updates fail after the first publish.** After publishing LSTs, `mod publish` maintains a central catalog CSV (`repos-lock.csv`) at a fixed Maven coordinate by downloading, merging, and re-uploading it. CodeArtifact package assets are immutable (re-publishing the same asset with different content returns HTTP 409), so from the second publish onward `mod publish` reports `Failed to update central effective repos-lock.csv` and the catalog stays at its first-publish contents. The LST JARs themselves publish at unique coordinates and are unaffected, but if your Moderne tenant reads its organization structure from this catalog (`moderne.organization.sources.*`), repos from later batches or runs will not appear in it until CodeArtifact supports overwriting the asset or the CLI handles it natively. Workaround: delete the `repos-lock` package version in CodeArtifact (`aws codeartifact delete-package-versions`) before a re-ingest so the first publish of the run recreates the catalog; note that in a batched run only that first publish succeeds in writing it, so a complete catalog requires an unbatched or org-mode run.
+- **Build logs are not stored in CodeArtifact.** Its Maven endpoint rejects non-Maven log artifact paths, so publish.sh skips the log upload (the logs remain in the local `log.zip`/`syncs.zip`).
+- **Package versions show as "Unfinished" in the CodeArtifact console.** The CLI uploads artifacts directly without a `maven-metadata.xml`, which CodeArtifact uses to mark versions "Published". Unfinished versions are excluded from version listings but remain downloadable at their direct URLs, which is how the platform consumes them.
+- This CodeArtifact path is implemented in `publish.sh` (bash) only; the PowerShell `publish.ps1` entrypoint does not include it.
+
+### Example
+
+```bash
+docker run --rm \
+  -p 8080:8080 \
+  -v $(pwd)/data:/var/moderne \
+  -e PUBLISH_URL=https://my-domain-111122223333.d.codeartifact.us-east-1.amazonaws.com/maven/my-repo/ \
+  -e CODEARTIFACT_DOMAIN=my-domain \
+  -e CODEARTIFACT_DOMAIN_OWNER=111122223333 \
+  -e CODEARTIFACT_REGION=us-east-1 \
+  -e BATCH_SIZE=50 \
+  mass-ingest
+```
 
 ## Generating repository lists
 

--- a/gradle/init-codeartifact.gradle
+++ b/gradle/init-codeartifact.gradle
@@ -1,0 +1,90 @@
+// Injects an AWS CodeArtifact Maven repository (with credentials) into every Gradle
+// build the Moderne CLI runs, so dependency and plugin resolution can reach CodeArtifact
+// without modifying each project. Registered via:
+//   mod config build gradle arguments edit --init-script=/app/gradle/init-codeartifact.gradle
+//
+// The endpoint comes from PUBLISH_URL and the token from CODEARTIFACT_AUTH_TOKEN, both
+// set by publish.sh. The token is short-lived and refreshed before every build, so the
+// build always sees a valid token.
+def codeartifactUrl = System.getenv("PUBLISH_URL")
+def codeartifactToken = System.getenv("CODEARTIFACT_AUTH_TOKEN")
+
+if (codeartifactUrl && codeartifactToken) {
+    def applyRepo = { repositories ->
+        // Don't clash with a repository the target project already named "codeartifact".
+        if (repositories.findByName("codeartifact") == null) {
+            repositories.maven {
+                name = "codeartifact"
+                url = uri(codeartifactUrl)
+                credentials {
+                    username = "aws"
+                    password = codeartifactToken
+                }
+            }
+        }
+    }
+
+    // Fully qualified: GradleVersion is not in the default script imports before ~7.1,
+    // and an unresolvable reference here would fail every build on exactly the older
+    // Gradle versions the gates below exist for.
+    def current = org.gradle.util.GradleVersion.current()
+    def hasBeforeSettings = current >= org.gradle.util.GradleVersion.version("6.0")  // Gradle.beforeSettings
+    def hasCentralRepos = current >= org.gradle.util.GradleVersion.version("6.8")    // dependencyResolutionManagement
+
+    // Plugin resolution (and the settings script's own buildscript classpath): both must be
+    // in place before the settings script is evaluated.
+    if (hasBeforeSettings) {
+        beforeSettings { settings ->
+            applyRepo(settings.pluginManagement.repositories)
+            applyRepo(settings.buildscript.repositories)
+        }
+    } else {
+        // Too late for the settings buildscript classpath (already resolved), but still in
+        // time for plugin resolution in project scripts.
+        settingsEvaluated { settings ->
+            applyRepo(settings.pluginManagement.repositories)
+        }
+    }
+
+    if (hasCentralRepos) {
+        // Dependency resolution on 6.8+. Add CodeArtifact to the settings-level (centralized)
+        // repositories after the settings script has declared its own, so the existing
+        // repositories keep priority. This covers PREFER_SETTINGS, FAIL_ON_PROJECT_REPOS, and
+        // PREFER_PROJECT projects that declare no project repositories of their own.
+        def preferProject = false
+        settingsEvaluated { settings ->
+            applyRepo(settings.dependencyResolutionManagement.repositories)
+            preferProject = settings.dependencyResolutionManagement.repositoriesMode.get() ==
+                    org.gradle.api.initialization.resolve.RepositoriesMode.PREFER_PROJECT
+        }
+        // Under PREFER_PROJECT a project that declares its own repositories ignores the
+        // settings repositories, so CodeArtifact must also be added at project level — but
+        // ONLY for those projects. Adding it to a project that relies solely on settings
+        // repositories would introduce its first project repository and thereby flip it off
+        // the settings repositories (dropping e.g. mavenCentral). Checked after evaluation so
+        // the project's own declarations are visible, and appended so they keep priority.
+        // buildscript repositories are never governed by repositoriesMode, so they are always
+        // safe to add for legacy plugin classpaths.
+        allprojects { project ->
+            project.buildscript {
+                applyRepo(repositories)
+            }
+            if (preferProject) {
+                project.afterEvaluate { p ->
+                    if (!p.repositories.isEmpty()) {
+                        applyRepo(p.repositories)
+                    }
+                }
+            }
+        }
+    } else {
+        // Pre-6.8 Gradle has no centralized repositories; project repositories are the only
+        // mechanism and are purely additive, so CodeArtifact can always be added there.
+        allprojects { project ->
+            project.buildscript {
+                applyRepo(repositories)
+            }
+            applyRepo(project.repositories)
+        }
+    }
+}

--- a/maven/settings-codeartifact.xml
+++ b/maven/settings-codeartifact.xml
@@ -1,0 +1,26 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <!--
+      Maven settings for resolving dependencies through AWS CodeArtifact during the build.
+      publish.sh registers this file (when CODEARTIFACT_DOMAIN is set) and exports both
+      ${env.PUBLISH_URL} (the CodeArtifact endpoint) and ${env.CODEARTIFACT_AUTH_TOKEN}.
+
+      The catch-all mirror routes all resolution through CodeArtifact, which must therefore
+      have an upstream connection for every external repository the build needs.
+    -->
+    <servers>
+        <server>
+            <id>codeartifact</id>
+            <username>aws</username>
+            <password>${env.CODEARTIFACT_AUTH_TOKEN}</password>
+        </server>
+    </servers>
+    <mirrors>
+        <mirror>
+            <id>codeartifact</id>
+            <name>AWS CodeArtifact</name>
+            <url>${env.PUBLISH_URL}</url>
+            <mirrorOf>*</mirrorOf>
+        </mirror>
+    </mirrors>
+</settings>

--- a/publish.sh
+++ b/publish.sh
@@ -153,8 +153,6 @@ run_startup_diagnostics() {
 configure_credentials() {
   info "Configuring credentials"
 
-  # BATCH_SIZE is consumed as a number by every publish path (split_into_batches); a
-  # non-numeric value would otherwise surface as an opaque bash arithmetic error.
   if [ -n "${BATCH_SIZE:-}" ] && ! [[ "${BATCH_SIZE}" =~ ^[0-9]+$ ]]; then
     die "BATCH_SIZE must be a non-negative integer, not '${BATCH_SIZE}'"
   fi
@@ -176,10 +174,8 @@ configure_credentials() {
   fi
 
   # Configure artifact repository
-  # AWS CodeArtifact (Maven repo with a short-lived, rotating auth token)
   if [ -n "${CODEARTIFACT_DOMAIN:-}" ]; then
     configure_codeartifact
-  # S3 configuration (S3 bucket URL should start with s3://)
   elif [[ "${PUBLISH_URL:-}" == "s3://"* ]]; then
     info "Configuring S3 artifact repository: ${PUBLISH_URL}"
 
@@ -231,9 +227,7 @@ configure_codeartifact() {
   info "Configuring AWS CodeArtifact Maven repository: ${PUBLISH_URL}"
 
   # The domain owner (12-digit account id) and region are embedded in the CodeArtifact
-  # host (<domain>-<owner>.d.codeartifact.<region>.amazonaws.com). Derive them so the
-  # token is always minted against the right account/region even when not set explicitly
-  # (the caller's default account/region is often wrong for a central artifacts account).
+  # host (<domain>-<owner>.d.codeartifact.<region>.amazonaws.com).
   local host="${PUBLISH_URL#*://}"; host="${host%%/*}"
   if [[ "$host" =~ -([0-9]{12})\.d\.codeartifact\.([a-z0-9-]+)\. ]]; then
     export CODEARTIFACT_DOMAIN_OWNER="${CODEARTIFACT_DOMAIN_OWNER:-${BASH_REMATCH[1]}}"
@@ -252,8 +246,6 @@ configure_codeartifact() {
     info "WARNING: CodeArtifact is configured for publishing, but no build dependency wiring was found. Uncomment the CodeArtifact build-tool lines in the Dockerfile so dependencies resolve from CodeArtifact rather than public repositories."
   fi
 
-  # The token is refreshed per batch, so anything that does not batch (org mode, or the
-  # default single-batch run) mints it only once and risks a build/publish past its expiry.
   if [ -n "${ORGANIZATION:-}" ]; then
     info "WARNING: org mode mints the CodeArtifact token once for the whole org. A build/publish that runs past the token lifetime will fail; raise CODEARTIFACT_TOKEN_DURATION or split the org if it is large."
   elif [[ "${BATCH_SIZE:-0}" -le 0 ]]; then
@@ -263,9 +255,7 @@ configure_codeartifact() {
   refresh_codeartifact_token || die "Unable to configure the CodeArtifact publish target"
 }
 
-# No-op when CodeArtifact is not in use, so it is safe to call unconditionally before each
-# batch. Returns non-zero rather than aborting, so a transient failure mid-run does not
-# discard the remaining batches.
+# No-op when CodeArtifact is not in use. transient failure mid-run does not discard the remaining batches.
 refresh_codeartifact_token() {
   [ -n "${CODEARTIFACT_DOMAIN:-}" ] || return 0
 
@@ -294,14 +284,11 @@ refresh_codeartifact_token() {
     return 1
   fi
 
-  # CodeArtifact's Basic-auth username is always "aws".
   if ! mod config lsts artifacts maven edit "${PUBLISH_URL}" --user aws --password "$token"; then
     info "Failed to apply the CodeArtifact token to the publish configuration"
     return 1
   fi
 
-  # Exported only after the publish config accepted the token, so the build and the publish
-  # step never end up on different tokens.
   export CODEARTIFACT_AUTH_TOKEN="$token"
 }
 
@@ -393,8 +380,6 @@ build_and_upload_repos() {
   mod git sync csv "$clone_dir" "$partition_file" --with-sources
   mod log syncs add "$clone_dir" "$DATA_DIR/syncs.zip" --last-sync
 
-  # Refreshed after the (potentially long) clone and right before the build/publish that use
-  # it, so the token can't expire mid-batch.
   refresh_codeartifact_token || info "Token refresh failed; continuing with the existing token"
 
   # kill a build if it takes too long assuming it's hung indefinitely
@@ -415,8 +400,6 @@ send_logs() {
   local index=$1
   local timestamp=$(date +"%Y%m%d%H%M")
 
-  # CodeArtifact's Maven endpoint rejects the non-Maven log artifact paths, so skip the
-  # upload rather than issue a PUT that always 400s. Logs stay in the local log.zip/syncs.zip.
   if [ -n "${CODEARTIFACT_DOMAIN:-}" ]; then
     info "Skipping build-log upload: AWS CodeArtifact does not accept non-Maven log artifacts"
     return 0

--- a/publish.sh
+++ b/publish.sh
@@ -99,6 +99,7 @@ ingest_repos() {
     mod git sync csv "$clone_dir" "$csv_file" --organization "$ORGANIZATION" --with-sources
     mod log syncs add "$clone_dir" "$DATA_DIR/syncs.zip" --last-sync
     mod git pull "$clone_dir"
+    refresh_codeartifact_token || info "Token refresh failed; continuing with the existing token"
     mod build "$clone_dir" --no-download
     mod publish "$clone_dir"
     mod log builds add "$clone_dir" "$DATA_DIR/log.zip" --last-build
@@ -152,6 +153,12 @@ run_startup_diagnostics() {
 configure_credentials() {
   info "Configuring credentials"
 
+  # BATCH_SIZE is consumed as a number by every publish path (split_into_batches); a
+  # non-numeric value would otherwise surface as an opaque bash arithmetic error.
+  if [ -n "${BATCH_SIZE:-}" ] && ! [[ "${BATCH_SIZE}" =~ ^[0-9]+$ ]]; then
+    die "BATCH_SIZE must be a non-negative integer, not '${BATCH_SIZE}'"
+  fi
+
   # Configure Moderne tenant if token provided
   if [ -n "${MODERNE_TOKEN:-}" ] && [ -n "${MODERNE_TENANT:-}" ]; then
     info "Configuring Moderne tenant: ${MODERNE_TENANT}"
@@ -169,8 +176,11 @@ configure_credentials() {
   fi
 
   # Configure artifact repository
+  # AWS CodeArtifact (Maven repo with a short-lived, rotating auth token)
+  if [ -n "${CODEARTIFACT_DOMAIN:-}" ]; then
+    configure_codeartifact
   # S3 configuration (S3 bucket URL should start with s3://)
-  if [[ "${PUBLISH_URL:-}" == "s3://"* ]]; then
+  elif [[ "${PUBLISH_URL:-}" == "s3://"* ]]; then
     info "Configuring S3 artifact repository: ${PUBLISH_URL}"
 
     # Build the command with proper quoting
@@ -205,6 +215,94 @@ configure_credentials() {
   else
     die "PUBLISH_URL must be supplied via environment variable. For S3, use s3:// URL format. For Maven/Artifactory, also provide PUBLISH_USER/PUBLISH_PASSWORD or PUBLISH_TOKEN"
   fi
+}
+
+# CodeArtifact's Basic-auth token expires within 12h, so it is minted at runtime and
+# refreshed before every batch; the same token reaches the build through
+# maven/settings-codeartifact.xml and gradle/init-codeartifact.gradle, which both read
+# ${CODEARTIFACT_AUTH_TOKEN}.
+configure_codeartifact() {
+  if [ -z "${PUBLISH_URL:-}" ]; then
+    die "PUBLISH_URL must point at the CodeArtifact Maven endpoint when CODEARTIFACT_DOMAIN is set (e.g. https://<domain>-<owner>.d.codeartifact.<region>.amazonaws.com/maven/<repository>/)"
+  fi
+  if [[ "${PUBLISH_URL}" != "https://"* && "${PUBLISH_URL}" != "http://"* ]]; then
+    die "PUBLISH_URL must be the CodeArtifact Maven HTTPS endpoint, not '${PUBLISH_URL}'. Unset CODEARTIFACT_DOMAIN to use S3/Artifactory instead."
+  fi
+  info "Configuring AWS CodeArtifact Maven repository: ${PUBLISH_URL}"
+
+  # The domain owner (12-digit account id) and region are embedded in the CodeArtifact
+  # host (<domain>-<owner>.d.codeartifact.<region>.amazonaws.com). Derive them so the
+  # token is always minted against the right account/region even when not set explicitly
+  # (the caller's default account/region is often wrong for a central artifacts account).
+  local host="${PUBLISH_URL#*://}"; host="${host%%/*}"
+  if [[ "$host" =~ -([0-9]{12})\.d\.codeartifact\.([a-z0-9-]+)\. ]]; then
+    export CODEARTIFACT_DOMAIN_OWNER="${CODEARTIFACT_DOMAIN_OWNER:-${BASH_REMATCH[1]}}"
+    export CODEARTIFACT_REGION="${CODEARTIFACT_REGION:-${BASH_REMATCH[2]}}"
+  fi
+
+  # Register the Maven settings at runtime, only when CodeArtifact is selected: its catch-all
+  # mirror reads ${env.PUBLISH_URL}, so baking it in would break Maven builds in a
+  # non-CodeArtifact run of the same image. A user-provided /root/.m2/settings.xml (the
+  # "Custom Maven Settings" Dockerfile section) takes precedence.
+  if [ ! -f /root/.m2/settings.xml ] && [ -f /app/maven/settings-codeartifact.xml ]; then
+    mod config build maven settings edit /app/maven/settings-codeartifact.xml
+  fi
+
+  if [ ! -f /root/.m2/settings.xml ] && [ ! -f /app/maven/settings-codeartifact.xml ] && [ ! -f /app/gradle/init-codeartifact.gradle ]; then
+    info "WARNING: CodeArtifact is configured for publishing, but no build dependency wiring was found. Uncomment the CodeArtifact build-tool lines in the Dockerfile so dependencies resolve from CodeArtifact rather than public repositories."
+  fi
+
+  # The token is refreshed per batch, so anything that does not batch (org mode, or the
+  # default single-batch run) mints it only once and risks a build/publish past its expiry.
+  if [ -n "${ORGANIZATION:-}" ]; then
+    info "WARNING: org mode mints the CodeArtifact token once for the whole org. A build/publish that runs past the token lifetime will fail; raise CODEARTIFACT_TOKEN_DURATION or split the org if it is large."
+  elif [[ "${BATCH_SIZE:-0}" -le 0 ]]; then
+    info "WARNING: CodeArtifact tokens expire within 12h and are refreshed once per batch. Set BATCH_SIZE so each batch completes inside the token lifetime for long runs."
+  fi
+
+  refresh_codeartifact_token || die "Unable to configure the CodeArtifact publish target"
+}
+
+# No-op when CodeArtifact is not in use, so it is safe to call unconditionally before each
+# batch. Returns non-zero rather than aborting, so a transient failure mid-run does not
+# discard the remaining batches.
+refresh_codeartifact_token() {
+  [ -n "${CODEARTIFACT_DOMAIN:-}" ] || return 0
+
+  info "Refreshing AWS CodeArtifact authorization token"
+
+  local get_token_cmd=(aws codeartifact get-authorization-token
+    --domain "${CODEARTIFACT_DOMAIN}"
+    --query authorizationToken --output text)
+  if [ -n "${CODEARTIFACT_DOMAIN_OWNER:-}" ]; then
+    get_token_cmd+=(--domain-owner "${CODEARTIFACT_DOMAIN_OWNER}")
+  fi
+  if [ -n "${CODEARTIFACT_REGION:-}" ]; then
+    get_token_cmd+=(--region "${CODEARTIFACT_REGION}")
+  fi
+  if [ -n "${CODEARTIFACT_TOKEN_DURATION:-}" ]; then
+    get_token_cmd+=(--duration-seconds "${CODEARTIFACT_TOKEN_DURATION}")
+  fi
+
+  local token
+  if ! token=$("${get_token_cmd[@]}"); then
+    info "Failed to obtain a CodeArtifact authorization token (check that the AWS CLI is installed and IAM permissions / CODEARTIFACT_* settings are correct)"
+    return 1
+  fi
+  if [ -z "$token" ] || [ "$token" = "None" ]; then
+    info "CodeArtifact returned an empty authorization token"
+    return 1
+  fi
+
+  # CodeArtifact's Basic-auth username is always "aws".
+  if ! mod config lsts artifacts maven edit "${PUBLISH_URL}" --user aws --password "$token"; then
+    info "Failed to apply the CodeArtifact token to the publish configuration"
+    return 1
+  fi
+
+  # Exported only after the publish config accepted the token, so the build and the publish
+  # step never end up on different tokens.
+  export CODEARTIFACT_AUTH_TOKEN="$token"
 }
 
 # Clean any existing files
@@ -295,6 +393,10 @@ build_and_upload_repos() {
   mod git sync csv "$clone_dir" "$partition_file" --with-sources
   mod log syncs add "$clone_dir" "$DATA_DIR/syncs.zip" --last-sync
 
+  # Refreshed after the (potentially long) clone and right before the build/publish that use
+  # it, so the token can't expire mid-batch.
+  refresh_codeartifact_token || info "Token refresh failed; continuing with the existing token"
+
   # kill a build if it takes too long assuming it's hung indefinitely
   # defaults to 2700 seconds (45 minutes)
   local build_timeout="${BUILD_TIMEOUT:-2700}"
@@ -312,6 +414,13 @@ build_and_upload_repos() {
 send_logs() {
   local index=$1
   local timestamp=$(date +"%Y%m%d%H%M")
+
+  # CodeArtifact's Maven endpoint rejects the non-Maven log artifact paths, so skip the
+  # upload rather than issue a PUT that always 400s. Logs stay in the local log.zip/syncs.zip.
+  if [ -n "${CODEARTIFACT_DOMAIN:-}" ]; then
+    info "Skipping build-log upload: AWS CodeArtifact does not accept non-Maven log artifacts"
+    return 0
+  fi
 
   # Upload logs to S3
   if [[ "${PUBLISH_URL:-}" == "s3://"* ]]; then

--- a/publish.sh
+++ b/publish.sh
@@ -102,6 +102,7 @@ ingest_repos() {
     refresh_codeartifact_token || info "Token refresh failed; continuing with the existing token"
     mod build "$clone_dir" --no-download
     mod publish "$clone_dir"
+    finalize_codeartifact_versions "$csv_file" || info "Some CodeArtifact versions could not be finalized"
     mod log builds add "$clone_dir" "$DATA_DIR/log.zip" --last-build
     send_logs "org-$ORGANIZATION"
   else
@@ -243,7 +244,7 @@ configure_codeartifact() {
   fi
 
   if [ ! -f /root/.m2/settings.xml ] && [ ! -f /app/maven/settings-codeartifact.xml ] && [ ! -f /app/gradle/init-codeartifact.gradle ]; then
-    info "WARNING: CodeArtifact is configured for publishing, but no build dependency wiring was found. Uncomment the CodeArtifact build-tool lines in the Dockerfile so dependencies resolve from CodeArtifact rather than public repositories."
+    info "WARNING: CodeArtifact is configured for publishing, but no build dependency configuration was found. Uncomment the CodeArtifact build-tool lines in the Dockerfile so dependencies resolve from CodeArtifact rather than public repositories."
   fi
 
   if [ -n "${ORGANIZATION:-}" ]; then
@@ -284,12 +285,86 @@ refresh_codeartifact_token() {
     return 1
   fi
 
-  if ! mod config lsts artifacts maven edit "${PUBLISH_URL}" --user aws --password "$token"; then
+  if ! mod config lsts artifacts maven add "${PUBLISH_URL}" --user aws --password "$token"; then
     info "Failed to apply the CodeArtifact token to the publish configuration"
     return 1
   fi
 
   export CODEARTIFACT_AUTH_TOKEN="$token"
+}
+
+# CodeArtifact marks versions uploaded without a maven-metadata.xml as Unfinished, and its
+# Maven endpoint returns 404 for every asset of an Unfinished version.
+# see https://docs.aws.amazon.com/codeartifact/latest/ug/maven-curl.html
+# No-op when CodeArtifact is not in use; a failure leaves the versions hidden but recoverable
+# (rerun `aws codeartifact update-package-versions-status` manually), so callers only warn.
+finalize_codeartifact_versions() {
+  [ -n "${CODEARTIFACT_DOMAIN:-}" ] || return 0
+
+  local csv_file=$1
+  info "Finalizing CodeArtifact package versions to Published status"
+
+  # <domain>-<owner>.d.codeartifact.<region>.amazonaws.com/maven/<repository>/
+  local repository="${PUBLISH_URL##*/maven/}"
+  repository="${repository%%/*}"
+  if [ -z "$repository" ]; then
+    info "Could not derive the CodeArtifact repository name from PUBLISH_URL '${PUBLISH_URL}'"
+    return 1
+  fi
+
+  local aws_args=(--domain "${CODEARTIFACT_DOMAIN}" --repository "$repository" --format maven)
+  if [ -n "${CODEARTIFACT_DOMAIN_OWNER:-}" ]; then
+    aws_args+=(--domain-owner "${CODEARTIFACT_DOMAIN_OWNER}")
+  fi
+  if [ -n "${CODEARTIFACT_REGION:-}" ]; then
+    aws_args+=(--region "${CODEARTIFACT_REGION}")
+  fi
+
+  local path_column
+  path_column=$(head -n 1 "$csv_file" | tr -d '\r' | tr ',' '\n' | grep -n -x -i 'path' | cut -d: -f1)
+  if [ -z "$path_column" ]; then
+    info "No path column found in $csv_file; only finalizing the organization catalog packages"
+  fi
+
+  local coordinates
+  coordinates=$(
+    if [ -n "$path_column" ]; then
+      tail -n +2 "$csv_file" | cut -d, -f"$path_column" | tr -d '\r' | while IFS= read -r path; do
+        path="${path%/}"
+        if [[ "$path" == */* ]]; then
+          printf '%s %s\n' "$(dirname "$path" | tr '/' '.')" "$(basename "$path")"
+        fi
+      done
+    fi
+    # the organization catalog packages mod publish maintains alongside the LSTs
+    printf 'io.moderne.organization.sources repos\n'
+    printf 'io.moderne.organization.sources repos-lock\n'
+  )
+
+  local failed=0
+  local namespace package versions
+  while read -r namespace package; do
+    [ -n "$package" ] || continue
+    # a package is absent when its repository failed to build, or on the catalog packages
+    # before the first successful publish; both are expected, so a failed listing is skipped
+    versions=$(aws codeartifact list-package-versions "${aws_args[@]}" \
+      --namespace "$namespace" --package "$package" --status Unfinished \
+      --query 'versions[?origin.originType==`INTERNAL`].version' --output text 2>/dev/null) || continue
+    if [ -z "$versions" ] || [ "$versions" = "None" ]; then
+      continue
+    fi
+    # shellcheck disable=SC2086 # versions is a tab-separated list that must word-split
+    if aws codeartifact update-package-versions-status "${aws_args[@]}" \
+        --namespace "$namespace" --package "$package" --versions $versions \
+        --target-status Published > /dev/null; then
+      info "Published CodeArtifact version(s) of ${namespace}:${package}"
+    else
+      info "Failed to finalize ${namespace}:${package} version(s) ${versions}; they stay hidden from the Maven endpoint until published manually"
+      failed=1
+    fi
+  done <<< "$coordinates"
+
+  return $failed
 }
 
 # Clean any existing files
@@ -392,6 +467,7 @@ build_and_upload_repos() {
   fi
 
   mod publish "$clone_dir"
+  finalize_codeartifact_versions "$partition_file" || info "Some CodeArtifact versions could not be finalized"
   mod log builds add "$clone_dir" "$DATA_DIR/log.zip" --last-build
   return $ret
 }


### PR DESCRIPTION
## Problem

The mass-ingest examples can publish LSTs to S3, a generic Maven repository (username/password), or Artifactory, but there is no path for AWS CodeArtifact. CodeArtifact is a Basic-auth Maven repository, so on the surface it fits the existing `PUBLISH_USER`/`PUBLISH_PASSWORD` branch, but three things make it a genuine gap:

1. The password is a short-lived token, not a static secret. A CodeArtifact token is minted with `aws codeartifact get-authorization-token` and expires within 12h, whereas the current flow configures credentials once at startup, so a scheduled or long-running ingest goes stale mid-run.
2. Dependency resolution during the build is not covered. `mod build` delegates to each project's own Maven or Gradle, which need a `settings.xml` server/mirror and a Gradle init script respectively, and the same rotating token has to reach both the build and the publish step.
3. Versions uploaded without a `maven-metadata.xml` stay in `Unfinished` status, and CodeArtifact's Maven endpoint returns 404 for them, so artifacts published by the CLI would not be downloadable by the platform without an extra finalization step.

- fixes: https://github.com/moderneinc/mass-ingest-example/issues/84

## Solution

- `publish.sh` mints a CodeArtifact token and re-applies it to the publish target and the build (via `CODEARTIFACT_AUTH_TOKEN`), once at startup and again before every batch, so it never goes stale. A `CODEARTIFACT_DOMAIN` variable selects the path; the domain owner and region are derived from `PUBLISH_URL` when not set explicitly.
- After each publish, `publish.sh` finalizes the uploaded package versions to `Published` status with `aws codeartifact update-package-versions-status`, since CodeArtifact hides `Unfinished` versions from its Maven endpoint. Without this the LSTs and the `repos-lock.csv` catalog would be invisible to the platform.
- `maven/settings-codeartifact.xml` (new) adds a CodeArtifact `<server>`/`<mirror>` whose URL and password read from the environment. It is registered at runtime only when CodeArtifact is selected, so the same image still builds Maven projects in S3 or Artifactory runs.
- `gradle/init-codeartifact.gradle` (new) injects the CodeArtifact repository and credentials for dependency and plugin resolution across Gradle versions and `RepositoriesMode` settings, without displacing a project's existing repositories.
- `Dockerfile` gains an opt-in section that installs the AWS CLI and wires the build files, keeping all token-dependent configuration at runtime.
- `README.md` and `.env.example` document the CodeArtifact path, including IAM-role authentication and required IAM actions, a bounded `BATCH_SIZE`, and the known limitations of a Maven-format CodeArtifact repository (immutable assets freezing the organization catalog, fixed external-connection list, CSV-driven platform consumption, no build-log storage).

## Testing

Validated end to end against a real AWS CodeArtifact domain (with a Maven Central and a Gradle Plugin Portal upstream), using batched runs over public repositories:

- Token minted at startup and refreshed before every batch; domain owner and region correctly derived from `PUBLISH_URL`; `CODEARTIFACT_TOKEN_DURATION` honored.
- LSTs and the `repos-lock.csv` catalog published and, after finalization, downloadable at their direct Maven-endpoint URLs (verified 404 before finalization, 200 after).
- Maven dependency resolution fully mirrored through CodeArtifact (all downloads in the build log served by the CodeArtifact endpoint, none direct from Central), using the runtime-registered `settings-codeartifact.xml`.
- Gradle plugin and buildscript resolution served through the CodeArtifact Gradle Plugin Portal upstream via the init script; project-declared repositories keep priority as designed.
- Documented limitations reproduced as described: immutable `repos-lock` asset (HTTP 409 on re-publish, LSTs unaffected), build-log upload skipped, and unresolvable dependencies for repositories that need an upstream outside CodeArtifact's supported external connections.

The token refresh cadence and per-batch continue-on-failure behavior were additionally validated with stubbed AWS and CLI calls in a locally deployed test environment, and the Gradle init script against real builds on Gradle 5.6.4 through 9.5 across all `RepositoriesMode` values.
