### PR TITLE
Run mass-ingest containers as a non-root user

### DIFF
--- a/1-quickstart/README.md
+++ b/1-quickstart/README.md
@@ -92,7 +92,7 @@ docker run --rm \
 docker run --rm \
   -p 8080:8080 \
   -v $(pwd)/data:/var/moderne \
-  -v ~/.aws:/root/.aws:ro \
+  -v ~/.aws:/home/moderne/.aws:ro \
   -e PUBLISH_URL=s3://your-bucket \
   -e S3_PROFILE=your-profile \
   mass-ingest:quickstart
@@ -107,7 +107,7 @@ aws sso login --profile your-profile
 docker run --rm \
   -p 8080:8080 \
   -v $(pwd)/data:/var/moderne \
-  -v ~/.aws:/root/.aws:ro \
+  -v ~/.aws:/home/moderne/.aws:ro \
   -e PUBLISH_URL=s3://your-bucket \
   -e S3_PROFILE=your-profile \
   mass-ingest:quickstart
@@ -231,7 +231,7 @@ Mount it when running the container:
 docker run --rm \
   -p 8080:8080 \
   -v $(pwd)/data:/var/moderne \
-  -v $(pwd)/.git-credentials:/root/.git-credentials:ro \
+  -v $(pwd)/.git-credentials:/home/moderne/.git-credentials:ro \
   -e PUBLISH_URL=https://your-artifactory.com/artifactory/moderne-ingest/ \
   -e PUBLISH_USER=your-username \
   -e PUBLISH_PASSWORD=your-password \
@@ -243,7 +243,7 @@ Alternatively, use SSH keys by mounting your `.ssh` directory:
 docker run --rm \
   -p 8080:8080 \
   -v $(pwd)/data:/var/moderne \
-  -v $(pwd)/.ssh:/root/.ssh:ro \
+  -v $(pwd)/.ssh:/home/moderne/.ssh:ro \
   -e PUBLISH_URL=https://your-artifactory.com/artifactory/moderne-ingest/ \
   -e PUBLISH_USER=your-username \
   -e PUBLISH_PASSWORD=your-password \
@@ -255,20 +255,24 @@ docker run --rm \
 If your artifact repository or source control uses self-signed certificates:
 
 ```dockerfile
-COPY mycert.crt /root/mycert.crt
-RUN /usr/lib/jvm/temurin-21-jdk/bin/keytool -import -file /root/mycert.crt \
+COPY mycert.crt /opt/certs/mycert.crt
+RUN /usr/lib/jvm/temurin-21-jdk/bin/keytool -import -file /opt/certs/mycert.crt \
     -keystore /usr/lib/jvm/temurin-21-jdk/lib/security/cacerts
 RUN mod config http trust-store edit java-home
 ```
+
+The keytool import modifies the JDK trust store and must run as root, so keep it above the `USER 1000` switch in the Dockerfile. The `mod config` command must run as the non-root user, so place it in the CLI CONFIGURATION section below the switch.
 
 ### Maven settings
 
 If your projects require custom Maven settings:
 
 ```dockerfile
-COPY maven/settings.xml /root/.m2/settings.xml
-RUN mod config build maven settings edit /root/.m2/settings.xml
+COPY --chown=1000:0 maven/settings.xml /home/moderne/.m2/settings.xml
+RUN mod config build maven settings edit /home/moderne/.m2/settings.xml
 ```
+
+Place these in the CLI CONFIGURATION section of the Dockerfile (below the `USER 1000` switch) so the settings land in the non-root user's home directory.
 
 ### Additional language support
 
@@ -306,6 +310,13 @@ docker run --rm \
 - Larger batches are faster but require more disk space
 
 For parallel processing across multiple containers, see [3-scalability](../3-scalability/).
+
+## Non-root user
+
+The container runs as a non-root user (`moderne`, UID 1000) rather than root. This matters in two places:
+
+- **Bind mounts for data**: a host directory mounted at `/var/moderne` must be writable by UID 1000. On Linux, create the directory as your regular user (`mkdir data`) before running the container; if Docker auto-creates it, it will be owned by root and the container cannot write to it.
+- **Mounted credentials**: files mounted into `/home/moderne` (`.git-credentials`, `.ssh`, `.aws`) must be readable by UID 1000. SSH private keys are typically mode 600, so on Linux they must be owned by UID 1000 on the host.
 
 ## Storage requirements
 

--- a/2-observability/README.md
+++ b/2-observability/README.md
@@ -139,7 +139,7 @@ services:
     volumes:
       - data:/var/moderne
       - ../repos.csv:/app/repos.csv
-      - ./.git-credentials:/root/.git-credentials:ro  # Uncomment this line
+      - ./.git-credentials:/home/moderne/.git-credentials:ro  # Uncomment this line
 ```
 
 Alternatively, use SSH keys by uncommenting the SSH volume mount:
@@ -149,7 +149,7 @@ services:
     volumes:
       - data:/var/moderne
       - ../repos.csv:/app/repos.csv
-      - ./.ssh:/root/.ssh:ro  # Uncomment this line
+      - ./.ssh:/home/moderne/.ssh:ro  # Uncomment this line
 ```
 
 ### Custom repos.csv location

--- a/2-observability/docker-compose.yml
+++ b/2-observability/docker-compose.yml
@@ -15,9 +15,9 @@ services:
       - data:/var/moderne
       - ../repos.csv:/app/repos.csv
       # Uncomment to mount git credentials for private repositories
-      # - ./.git-credentials:/root/.git-credentials:ro
+      # - ./.git-credentials:/home/moderne/.git-credentials:ro
       # Or mount SSH keys instead:
-      # - ./.ssh:/root/.ssh:ro
+      # - ./.ssh:/home/moderne/.ssh:ro
     networks:
       - monitoring
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,17 +20,8 @@ FROM eclipse-temurin:25-jdk AS jdk25
 FROM jdk25 AS dependencies
 RUN apt-get -y update && apt-get install -y curl git git-lfs jq libxml2-utils unzip wget zip vim && git lfs install
 
-# Create the non-root user the container runs as. System-level installations
-# below still happen as root; the image drops privileges in the final stage
-# (see DROP PRIVILEGES) so the container never runs as root.
-#
-# The user's primary group is root (GID 0) and its writable directories are
-# group-writable, so the image also works on platforms that run containers
-# with an arbitrary UID and GID 0 (e.g. OpenShift).
-#
-# Ubuntu 24.04 base images ship a default `ubuntu` user; remove it so the
-# `moderne` user can take UID 1000, which matches the typical host user UID
-# and keeps volume-mounted files readable.
+# Create the non-root user the container runs as. 
+# Ubuntu 24.04 base images ship a default `ubuntu` user; remove it so the`moderne` user can take UID 1000.
 RUN userdel -r ubuntu 2>/dev/null; \
     useradd --uid 1000 --gid 0 --create-home --shell /bin/bash moderne && \
     chmod g=u /home/moderne && \
@@ -102,8 +93,6 @@ RUN if [ -n "${MODERNE_CLI_VERSION}" ]; then \
 RUN chmod +x /usr/local/bin/modw && ln -sf modw /usr/local/bin/mod
 
 # Write wrapper properties so modw knows the version policy at runtime.
-# These live in the moderne user's home because the CLI resolves its
-# configuration from the home directory of the user running it.
 RUN mkdir -p /home/moderne/.moderne/cli/dist && \
     if [ -n "${MODERNE_CLI_VERSION}" ]; then \
         echo "version=${MODERNE_CLI_VERSION}" > /home/moderne/.moderne/cli/dist/moderne-wrapper.properties; \
@@ -123,10 +112,6 @@ RUN mkdir -p /home/moderne/.moderne/cli/dist && \
 ################################################################################
 # Most projects use Maven/Gradle wrappers and don't need these installations.
 # Uncomment only if your repositories specifically require them.
-#
-# Everything in this stage installs system-level tooling and runs as root.
-# Commands that configure the Moderne CLI (`mod config ...`) live in the
-# CLI CONFIGURATION section further down, after the switch to the non-root user.
 
 FROM modcli AS language-support
 
@@ -134,7 +119,6 @@ FROM modcli AS language-support
 # Install one or more Gradle versions for repos that lack a Gradle wrapper.
 # To add versions for repos with older build scripts, add them to GRADLE_EXTRA_VERSIONS (comma-separated).
 # Then use the `gradleVersion` column in repos.csv to select which version to use per repo.
-# The installations are registered with the CLI in the CLI CONFIGURATION section below.
 ARG GRADLE_VERSION=8.14
 ARG GRADLE_EXTRA_VERSIONS=
 RUN mkdir -p /opt/gradle && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,22 @@ FROM eclipse-temurin:25-jdk AS jdk25
 FROM jdk25 AS dependencies
 RUN apt-get -y update && apt-get install -y curl git git-lfs jq libxml2-utils unzip wget zip vim && git lfs install
 
+# Create the non-root user the container runs as. System-level installations
+# below still happen as root; the image drops privileges in the final stage
+# (see DROP PRIVILEGES) so the container never runs as root.
+#
+# The user's primary group is root (GID 0) and its writable directories are
+# group-writable, so the image also works on platforms that run containers
+# with an arbitrary UID and GID 0 (e.g. OpenShift).
+#
+# Ubuntu 24.04 base images ship a default `ubuntu` user; remove it so the
+# `moderne` user can take UID 1000, which matches the typical host user UID
+# and keeps volume-mounted files readable.
+RUN userdel -r ubuntu 2>/dev/null; \
+    useradd --uid 1000 --gid 0 --create-home --shell /bin/bash moderne && \
+    chmod g=u /home/moderne && \
+    install -d -o moderne -g 0 -m 775 /app /var/moderne
+
 # Gather various JDK versions
 COPY --from=jdk8 /opt/java/openjdk /usr/lib/jvm/temurin-8-jdk
 COPY --from=jdk11 /opt/java/openjdk /usr/lib/jvm/temurin-11-jdk
@@ -85,15 +101,18 @@ RUN if [ -n "${MODERNE_CLI_VERSION}" ]; then \
 # Make modw executable and create mod symlink
 RUN chmod +x /usr/local/bin/modw && ln -sf modw /usr/local/bin/mod
 
-# Write wrapper properties so modw knows the version policy at runtime
-RUN mkdir -p /root/.moderne/cli/dist && \
+# Write wrapper properties so modw knows the version policy at runtime.
+# These live in the moderne user's home because the CLI resolves its
+# configuration from the home directory of the user running it.
+RUN mkdir -p /home/moderne/.moderne/cli/dist && \
     if [ -n "${MODERNE_CLI_VERSION}" ]; then \
-        echo "version=${MODERNE_CLI_VERSION}" > /root/.moderne/cli/dist/moderne-wrapper.properties; \
+        echo "version=${MODERNE_CLI_VERSION}" > /home/moderne/.moderne/cli/dist/moderne-wrapper.properties; \
     elif [ "${MODERNE_CLI_STAGE}" = "snapshot" ]; then \
-        echo "version=LATEST" > /root/.moderne/cli/dist/moderne-wrapper.properties; \
+        echo "version=LATEST" > /home/moderne/.moderne/cli/dist/moderne-wrapper.properties; \
     else \
-        echo "version=RELEASE" > /root/.moderne/cli/dist/moderne-wrapper.properties; \
-    fi
+        echo "version=RELEASE" > /home/moderne/.moderne/cli/dist/moderne-wrapper.properties; \
+    fi && \
+    chown -R moderne:0 /home/moderne/.moderne && chmod -R g=u /home/moderne/.moderne
 
 # Credential configuration has been moved to runtime (publish.sh/publish.ps1) to avoid
 # baking sensitive credentials into Docker image layers. Credentials are now passed as
@@ -104,6 +123,10 @@ RUN mkdir -p /root/.moderne/cli/dist && \
 ################################################################################
 # Most projects use Maven/Gradle wrappers and don't need these installations.
 # Uncomment only if your repositories specifically require them.
+#
+# Everything in this stage installs system-level tooling and runs as root.
+# Commands that configure the Moderne CLI (`mod config ...`) live in the
+# CLI CONFIGURATION section further down, after the switch to the non-root user.
 
 FROM modcli AS language-support
 
@@ -111,6 +134,7 @@ FROM modcli AS language-support
 # Install one or more Gradle versions for repos that lack a Gradle wrapper.
 # To add versions for repos with older build scripts, add them to GRADLE_EXTRA_VERSIONS (comma-separated).
 # Then use the `gradleVersion` column in repos.csv to select which version to use per repo.
+# The installations are registered with the CLI in the CLI CONFIGURATION section below.
 ARG GRADLE_VERSION=8.14
 ARG GRADLE_EXTRA_VERSIONS=
 RUN mkdir -p /opt/gradle && \
@@ -122,9 +146,6 @@ RUN mkdir -p /opt/gradle && \
         unzip -d /opt/gradle gradle-${v}-bin.zip && \
         rm gradle-${v}-bin.zip; \
     done
-
-# Register all Gradle installations so the CLI can select the right version per repo.
-RUN mod config build gradle installation edit $(find /opt/gradle -maxdepth 1 -mindepth 1 -type d | sort -V)
 ENV PATH="${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin"
 
 # Maven (comment if projects don't use Maven without a wrapper)
@@ -164,12 +185,12 @@ RUN ln -s /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 # RUN chmod +x /usr/local/bin/bazel
 
 # Node.js - multiple versions (uncomment for JavaScript/TypeScript projects)
-# Also uncomment the FROM node:XX lines near the top of this file
+# Also uncomment the FROM node:XX lines near the top of this file and the
+# `mod config node installation edit` line in the CLI CONFIGURATION section below.
 # COPY --from=node20 /usr/local /opt/node/node-20
 # COPY --from=node22 /usr/local /opt/node/node-22
 # COPY --from=node24 /usr/local /opt/node/node-24
 # ENV PATH="/opt/node/node-24/bin:${PATH}"
-# RUN mod config node installation edit /opt/node/node-20/bin/node /opt/node/node-22/bin/node # /opt/node/node-24/bin/node
 
 # Python 3.11 (uncomment for Python projects)
 # Install prerequisites and COPY the deadsnakes PPA
@@ -204,79 +225,22 @@ RUN ln -s /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 # RUN apt-get install -y dotnet-sdk-8.0
 
 ################################################################################
-# OPTIONAL: Custom Maven Settings (uncomment if needed)
-################################################################################
-# Most projects don't need custom Maven settings. Only uncomment if your
-# projects require specific Maven configuration.
-
-# Configure Maven Settings if they are required to build (choose betwween a settings file withing this repo or the docker image variant):
-# COPY maven/settings.xml /root/.m2/settings.xml
-# RUN cp $MAVEN_CONFIG/settings.xml /root/.m2/settings.xml # For custom maven docker imagee
-# COPY maven/settings-security.xml /root/.m2/settings-security.xml
-# RUN mod config build maven settings edit /root/.m2/settings.xml
-
-################################################################################
-# OPTIONAL: Custom NPM Configuration (uncomment if needed)
-################################################################################
-# If your JavaScript/TypeScript projects require a custom npm registry or
-# authentication, uncomment the following to configure an .npmrc file.
-
-# COPY npm/.npmrc /root/.npmrc
-
-################################################################################
-# OPTIONAL: Custom Python/pip Configuration (uncomment if needed)
-################################################################################
-# If your Python projects require a private package index or authentication,
-# uncomment the following to configure pip.
-
-# RUN mkdir -p /root/.config/pip
-# COPY python/pip.conf /root/.config/pip/pip.conf
-
-################################################################################
-# OPTIONAL: Custom build steps (uncomment if needed)
-################################################################################
-# If your repositories include JavaScript or Python projects, uncomment the
-# following to configure the Moderne CLI to parse those languages.
-
-# RUN mkdir -p /root/.moderne/cli
-# COPY moderne.yml /root/.moderne/cli/moderne.yml
-
-################################################################################
 # RUNTIME CONFIGURATION
 ################################################################################
 
 FROM language-support AS runner
-
-# Git authentication configuration
-# Git credentials are configured at runtime via volume mounts to avoid baking secrets into the image.
-# Configure git to use the credential store that will be mounted at runtime
-RUN git config --global credential.helper "store --file=/root/.git-credentials"
-# Optionally disable SSL verification if needed
-# RUN git config --global http.sslVerify false
-
-# Mount git credentials at runtime with:
-# docker run -v $(pwd)/.git-credentials:/root/.git-credentials:ro ...
-#
-# .git-credentials format (one line per host):
-# https://<username>:<password>@github.com
-# https://<token-name>:<token>@gitlab.com
-
-# SSH keys for git authentication (if needed instead of https credentials)
-# Mount at runtime to avoid baking secrets into the image:
-# docker run -v $(pwd)/.ssh:/root/.ssh:ro ...
-#
-# Ensure your .ssh directory contains:
-# - id_rsa (private key with 600 permissions)
-# - known_hosts (with 644 permissions)
 
 ################################################################################
 # OPTIONAL: Self-signed Certificates (uncomment if needed)
 ################################################################################
 # Only needed if your artifact repository, source control, or Moderne tenant
 # uses self-signed certificates.
+#
+# This section modifies JDK trust stores, so it must stay above the
+# DROP PRIVILEGES switch below (it runs as root).
 
 # Place all .crt files in a certs/ directory next to the Dockerfile, then uncomment:
-# COPY certs/ /root/certs/
+# COPY certs/ /opt/certs/
 #
 # Edit this list to match the JDKs installed above:
 # ENV CACERTS_PATHS="\
@@ -286,7 +250,7 @@ RUN git config --global credential.helper "store --file=/root/.git-credentials"
 #   /usr/lib/jvm/temurin-21-jdk/lib/security/cacerts \
 #   /usr/lib/jvm/temurin-25-jdk/lib/security/cacerts"
 #
-# RUN for cert in /root/certs/*.crt; do \
+# RUN for cert in /opt/certs/*.crt; do \
 #       alias=$(basename "$cert" .crt); \
 #       for cacerts in $CACERTS_PATHS; do \
 #           keytool -import -noprompt -trustcacerts \
@@ -296,12 +260,14 @@ RUN git config --global credential.helper "store --file=/root/.git-credentials"
 #             -keystore "$cacerts"; \
 #       done; \
 #     done
-# RUN mod config http trust-store edit java-home
+#
+# Also uncomment the `mod config http trust-store edit java-home` line in the
+# CLI CONFIGURATION section below.
 
 # mvnw scripts in maven projects may attempt to download maven-wrapper jars using wget.
 # If using self-signed certs, UNCOMMENT the following to concatenate them for wget:
-# RUN cat /root/certs/*.crt > /root/ca-bundle.crt
-# RUN echo "ca_certificate = /root/ca-bundle.crt" > /root/.wgetrc
+# RUN cat /opt/certs/*.crt > /opt/certs/ca-bundle.crt
+# RUN echo "ca_certificate = /opt/certs/ca-bundle.crt" >> /etc/wgetrc
 
 ################################################################################
 # OPTIONAL: 3-scalability (AWS Batch) setup
@@ -313,21 +279,92 @@ RUN git config --global credential.helper "store --file=/root/.git-credentials"
 # HTTP/HTTPS URLs work without this. Comment out if not needed:
 #RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
 #    unzip awscliv2.zip && \
-#    ./aws/install
+#    ./aws/install && \
+#    rm -rf awscliv2.zip aws/
 
 # Chunk script for AWS Batch parallel processing
 # Uncomment to include the chunk.sh script for 3-scalability:
 # COPY --chmod=755 3-scalability/chunk.sh chunk.sh
 
 ################################################################################
-# FINAL SETUP
+# DROP PRIVILEGES
 ################################################################################
+# Everything from here on runs as the non-root `moderne` user, and the
+# container itself runs as that user. `mod config ...` commands write to
+# $HOME/.moderne, so they must come after this switch.
+#
+# The numeric UID (rather than the user name) lets Kubernetes verify
+# `runAsNonRoot: true` without additional pod configuration.
+
+USER 1000
+ENV HOME=/home/moderne
+
+################################################################################
+# CLI CONFIGURATION
+################################################################################
+# CLI configuration is stored in the moderne user's home directory, so these
+# commands run after the switch to the non-root user.
+
+# Register all Gradle installations so the CLI can select the right version per repo.
+RUN mod config build gradle installation edit $(find /opt/gradle -maxdepth 1 -mindepth 1 -type d | sort -V)
+
+# Node.js (uncomment for JavaScript/TypeScript projects, along with the
+# installation in the Language Support section above)
+# RUN mod config node installation edit /opt/node/node-20/bin/node /opt/node/node-22/bin/node # /opt/node/node-24/bin/node
+
+# Custom Maven settings (uncomment if your projects require specific Maven
+# configuration; choose between a settings file within this repo or the docker image variant):
+# COPY --chown=1000:0 maven/settings.xml /home/moderne/.m2/settings.xml
+# RUN cp $MAVEN_CONFIG/settings.xml /home/moderne/.m2/settings.xml # For custom maven docker image
+# COPY --chown=1000:0 maven/settings-security.xml /home/moderne/.m2/settings-security.xml
+# RUN mod config build maven settings edit /home/moderne/.m2/settings.xml
+
+# Custom NPM configuration (uncomment if your JavaScript/TypeScript projects
+# require a custom npm registry or authentication):
+# COPY --chown=1000:0 npm/.npmrc /home/moderne/.npmrc
+
+# Custom Python/pip configuration (uncomment if your Python projects require
+# a private package index or authentication):
+# COPY --chown=1000:0 python/pip.conf /home/moderne/.config/pip/pip.conf
+
+# Custom build steps (uncomment if your repositories include JavaScript or
+# Python projects, so the Moderne CLI parses those languages):
+# COPY --chown=1000:0 moderne.yml /home/moderne/.moderne/cli/moderne.yml
+
+# Self-signed certificates (uncomment along with the certificate section above):
+# RUN mod config http trust-store edit java-home
 
 # OPTIONAL - Customize JVM options
 RUN mod config java options edit "-Xmx4g -Xss3m"
 
 # Disable Maven Central if your environment blocks access to repo.maven.apache.org
 # RUN mod config features no-maven-central
+
+# Git authentication configuration
+# Git credentials are configured at runtime via volume mounts to avoid baking secrets into the image.
+# The `store` credential helper reads /home/moderne/.git-credentials.
+RUN git config --global credential.helper store
+# Optionally disable SSL verification if needed
+# RUN git config --global http.sslVerify false
+
+# Mount git credentials at runtime with:
+# docker run -v $(pwd)/.git-credentials:/home/moderne/.git-credentials:ro ...
+#
+# .git-credentials format (one line per host):
+# https://<username>:<password>@github.com
+# https://<token-name>:<token>@gitlab.com
+
+# SSH keys for git authentication (if needed instead of https credentials)
+# Mount at runtime to avoid baking secrets into the image:
+# docker run -v $(pwd)/.ssh:/home/moderne/.ssh:ro ...
+#
+# Ensure your .ssh directory contains:
+# - id_rsa (private key with 600 permissions, owned by UID 1000)
+# - known_hosts (with 644 permissions)
+
+################################################################################
+# FINAL SETUP
+################################################################################
 
 # Available ports
 # 8080 - mod CLI monitor
@@ -337,13 +374,15 @@ EXPOSE 8080
 ENV CUSTOM_CI=true
 
 # Set the data directory for the publish script
+# NOTE: when bind-mounting a host directory here, ensure it is writable by
+# UID 1000 (e.g. `mkdir data` as your regular user before `docker run`).
 ENV DATA_DIR=/var/moderne
 
 # Copy scripts
-COPY --chmod=755 publish.sh publish.sh
-COPY --chmod=755 diagnostics/ diagnostics/
+COPY --chown=1000:0 --chmod=755 publish.sh publish.sh
+COPY --chown=1000:0 --chmod=755 diagnostics/ diagnostics/
 
 # Optional: mount from host
-COPY repos.csv repos.csv
+COPY --chown=1000:0 repos.csv repos.csv
 
 CMD ["./publish.sh", "repos.csv"]

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -209,11 +209,26 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
     git lfs install && \
     dnf clean all
 
+# Create the non-root user the container runs as. System-level installations
+# still happen as root; the image drops privileges in the final stage
+# (see DROP PRIVILEGES) so the container never runs as root.
+#
+# The user's primary group is root (GID 0) and its writable directories are
+# group-writable, so the image also works on platforms that run containers
+# with an arbitrary UID and GID 0 (e.g. OpenShift).
+RUN useradd --uid 1000 --gid 0 --create-home --shell /bin/bash moderne && \
+    chmod g=u /home/moderne && \
+    install -d -o moderne -g 0 -m 775 /app /var/moderne
+
 ################################################################################
 # MODERNE CLI + LANGUAGE SUPPORT
 ################################################################################
 # Credential configuration has been moved to runtime (publish.sh/publish.ps1)
 # to avoid baking sensitive credentials into Docker image layers.
+#
+# Everything in this stage installs system-level tooling and runs as root.
+# Commands that configure the Moderne CLI (`mod config ...`) live in the
+# CLI CONFIGURATION section further down, after the switch to the non-root user.
 
 FROM base AS language-support
 
@@ -223,19 +238,23 @@ WORKDIR /app
 COPY --from=downloader /tmp/modw /usr/local/bin/modw
 RUN chmod +x /usr/local/bin/modw && ln -sf modw /usr/local/bin/mod
 
-# Write wrapper properties so modw knows the version policy at runtime
+# Write wrapper properties so modw knows the version policy at runtime.
+# These live in the moderne user's home because the CLI resolves its
+# configuration from the home directory of the user running it.
 ARG MODERNE_CLI_VERSION
 ARG MODERNE_CLI_STAGE=release
-RUN mkdir -p /root/.moderne/cli/dist && \
+RUN mkdir -p /home/moderne/.moderne/cli/dist && \
     if [ -n "${MODERNE_CLI_VERSION}" ]; then \
-        echo "version=${MODERNE_CLI_VERSION}" > /root/.moderne/cli/dist/moderne-wrapper.properties; \
+        echo "version=${MODERNE_CLI_VERSION}" > /home/moderne/.moderne/cli/dist/moderne-wrapper.properties; \
     elif [ "${MODERNE_CLI_STAGE}" = "snapshot" ]; then \
-        echo "version=LATEST" > /root/.moderne/cli/dist/moderne-wrapper.properties; \
+        echo "version=LATEST" > /home/moderne/.moderne/cli/dist/moderne-wrapper.properties; \
     else \
-        echo "version=RELEASE" > /root/.moderne/cli/dist/moderne-wrapper.properties; \
-    fi
+        echo "version=RELEASE" > /home/moderne/.moderne/cli/dist/moderne-wrapper.properties; \
+    fi && \
+    chown -R moderne:0 /home/moderne/.moderne && chmod -R g=u /home/moderne/.moderne
 
 # Gradle (comment if projects don't use Gradle without a wrapper)
+# The installations are registered with the CLI in the CLI CONFIGURATION section below.
 ARG GRADLE_VERSION=8.14
 ARG GRADLE_EXTRA_VERSIONS=
 COPY --from=downloader /tmp/gradle-*.zip /tmp/
@@ -246,9 +265,6 @@ RUN mkdir -p /opt/gradle && \
         unzip -d /opt/gradle /tmp/gradle-${v}-bin.zip && \
         rm /tmp/gradle-${v}-bin.zip; \
     done
-
-# Register all Gradle installations so the CLI can select the right version per repo.
-RUN mod config build gradle installation edit $(find /opt/gradle -maxdepth 1 -mindepth 1 -type d | sort -V)
 ENV PATH="${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin"
 
 # Maven (comment if projects don't use Maven without a wrapper)
@@ -301,44 +317,10 @@ RUN ln -s /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 # RUN dnf install -y dotnet-sdk-8.0
 
 ################################################################################
-# OPTIONAL: Custom Maven Settings (uncomment if needed)
-################################################################################
-# Most projects don't need custom Maven settings. Only uncomment if your
-# projects require specific Maven configuration.
-
-# Configure Maven Settings if they are required to build (choose between a settings file within this repo or the docker image variant):
-# COPY maven/settings.xml /root/.m2/settings.xml
-# RUN cp $MAVEN_CONFIG/settings.xml /root/.m2/settings.xml # For custom maven docker image
-# COPY maven/settings-security.xml /root/.m2/settings-security.xml
-# RUN mod config build maven settings edit /root/.m2/settings.xml
-
-################################################################################
 # RUNTIME CONFIGURATION
 ################################################################################
 
 FROM language-support AS runner
-
-# Git authentication configuration
-# Git credentials are configured at runtime via volume mounts to avoid baking secrets into the image.
-# Configure git to use the credential store that will be mounted at runtime
-RUN git config --global credential.helper "store --file=/root/.git-credentials"
-# Optionally disable SSL verification if needed
-# RUN git config --global http.sslVerify false
-
-# Mount git credentials at runtime with:
-# docker run -v $(pwd)/.git-credentials:/root/.git-credentials:ro ...
-#
-# .git-credentials format (one line per host):
-# https://<username>:<password>@github.com
-# https://<token-name>:<token>@gitlab.com
-
-# SSH keys for git authentication (if needed instead of https credentials)
-# Mount at runtime to avoid baking secrets into the image:
-# docker run -v $(pwd)/.ssh:/root/.ssh:ro ...
-#
-# Ensure your .ssh directory contains:
-# - id_rsa (private key with 600 permissions)
-# - known_hosts (with 644 permissions)
 
 ################################################################################
 # OPTIONAL: Self-signed Certificates (uncomment if needed)
@@ -349,23 +331,27 @@ RUN git config --global credential.helper "store --file=/root/.git-credentials"
 # On RHEL/UBI, the preferred approach is to use the system trust store via
 # update-ca-trust. This is simpler than per-JDK keytool imports and works
 # correctly with FIPS crypto policies.
+#
+# This section modifies system and JDK trust stores, so it must stay above
+# the DROP PRIVILEGES switch below (it runs as root).
 
 # System trust store approach (recommended for UBI/RHEL):
 # COPY mycert.crt /etc/pki/ca-trust/source/anchors/mycert.crt
 # RUN update-ca-trust
-# RUN mod config http trust-store edit java-home
 
 # Alternative: per-JDK keytool import (if system trust store approach doesn't work)
-# COPY mycert.crt /root/mycert.crt
-# RUN keytool -import -noprompt -storepass changeit -file /root/mycert.crt -keystore $(readlink -f /usr/lib/jvm/java-1.8.0-openjdk)/jre/lib/security/cacerts
-# RUN keytool -import -noprompt -storepass changeit -file /root/mycert.crt -keystore $(readlink -f /usr/lib/jvm/java-11-openjdk)/lib/security/cacerts
-# RUN keytool -import -noprompt -storepass changeit -file /root/mycert.crt -keystore $(readlink -f /usr/lib/jvm/java-17-openjdk)/lib/security/cacerts
-# RUN keytool -import -noprompt -storepass changeit -file /root/mycert.crt -keystore $(readlink -f /usr/lib/jvm/java-21-openjdk)/lib/security/cacerts
-# RUN mod config http trust-store edit java-home
+# COPY mycert.crt /opt/certs/mycert.crt
+# RUN keytool -import -noprompt -storepass changeit -file /opt/certs/mycert.crt -keystore $(readlink -f /usr/lib/jvm/java-1.8.0-openjdk)/jre/lib/security/cacerts
+# RUN keytool -import -noprompt -storepass changeit -file /opt/certs/mycert.crt -keystore $(readlink -f /usr/lib/jvm/java-11-openjdk)/lib/security/cacerts
+# RUN keytool -import -noprompt -storepass changeit -file /opt/certs/mycert.crt -keystore $(readlink -f /usr/lib/jvm/java-17-openjdk)/lib/security/cacerts
+# RUN keytool -import -noprompt -storepass changeit -file /opt/certs/mycert.crt -keystore $(readlink -f /usr/lib/jvm/java-21-openjdk)/lib/security/cacerts
+#
+# With either approach, also uncomment the `mod config http trust-store edit java-home`
+# line in the CLI CONFIGURATION section below.
 
 # mvnw scripts in maven projects may attempt to download maven-wrapper jars using wget.
 # UNCOMMENT the following to set wget's CA certificate
-# RUN echo "ca_certificate = /root/mycert.crt" > /root/.wgetrc
+# RUN echo "ca_certificate = /opt/certs/mycert.crt" >> /etc/wgetrc
 
 ################################################################################
 # OPTIONAL: 3-scalability (AWS Batch) setup
@@ -381,14 +367,68 @@ RUN git config --global credential.helper "store --file=/root/.git-credentials"
 # COPY --chmod=755 3-scalability/chunk.sh chunk.sh
 
 ################################################################################
-# FINAL SETUP
+# DROP PRIVILEGES
 ################################################################################
+# Everything from here on runs as the non-root `moderne` user, and the
+# container itself runs as that user. `mod config ...` commands write to
+# $HOME/.moderne, so they must come after this switch.
+#
+# The numeric UID (rather than the user name) lets Kubernetes verify
+# `runAsNonRoot: true` without additional pod configuration.
+
+USER 1000
+ENV HOME=/home/moderne
+
+################################################################################
+# CLI CONFIGURATION
+################################################################################
+# CLI configuration is stored in the moderne user's home directory, so these
+# commands run after the switch to the non-root user.
+
+# Register all Gradle installations so the CLI can select the right version per repo.
+RUN mod config build gradle installation edit $(find /opt/gradle -maxdepth 1 -mindepth 1 -type d | sort -V)
+
+# Custom Maven settings (uncomment if your projects require specific Maven
+# configuration; choose between a settings file within this repo or the docker image variant):
+# COPY --chown=1000:0 maven/settings.xml /home/moderne/.m2/settings.xml
+# RUN cp $MAVEN_CONFIG/settings.xml /home/moderne/.m2/settings.xml # For custom maven docker image
+# COPY --chown=1000:0 maven/settings-security.xml /home/moderne/.m2/settings-security.xml
+# RUN mod config build maven settings edit /home/moderne/.m2/settings.xml
+
+# Self-signed certificates (uncomment along with the certificate section above):
+# RUN mod config http trust-store edit java-home
 
 # OPTIONAL - Customize JVM options
 RUN mod config java options edit "-Xmx4g -Xss3m"
 
 # Disable Maven Central if your environment blocks access to repo.maven.apache.org
 # RUN mod config features no-maven-central
+
+# Git authentication configuration
+# Git credentials are configured at runtime via volume mounts to avoid baking secrets into the image.
+# The `store` credential helper reads /home/moderne/.git-credentials.
+RUN git config --global credential.helper store
+# Optionally disable SSL verification if needed
+# RUN git config --global http.sslVerify false
+
+# Mount git credentials at runtime with:
+# docker run -v $(pwd)/.git-credentials:/home/moderne/.git-credentials:ro ...
+#
+# .git-credentials format (one line per host):
+# https://<username>:<password>@github.com
+# https://<token-name>:<token>@gitlab.com
+
+# SSH keys for git authentication (if needed instead of https credentials)
+# Mount at runtime to avoid baking secrets into the image:
+# docker run -v $(pwd)/.ssh:/home/moderne/.ssh:ro ...
+#
+# Ensure your .ssh directory contains:
+# - id_rsa (private key with 600 permissions, owned by UID 1000)
+# - known_hosts (with 644 permissions)
+
+################################################################################
+# FINAL SETUP
+################################################################################
 
 # Available ports
 # 8080 - mod CLI monitor
@@ -398,13 +438,15 @@ EXPOSE 8080
 ENV CUSTOM_CI=true
 
 # Set the data directory for the publish script
+# NOTE: when bind-mounting a host directory here, ensure it is writable by
+# UID 1000 (e.g. `mkdir data` as your regular user before `docker run`).
 ENV DATA_DIR=/var/moderne
 
 # Copy scripts
-COPY --chmod=755 publish.sh publish.sh
-COPY --chmod=755 diagnostics/ diagnostics/
+COPY --chown=1000:0 --chmod=755 publish.sh publish.sh
+COPY --chown=1000:0 --chmod=755 diagnostics/ diagnostics/
 
 # Optional: mount from host
-COPY repos.csv repos.csv
+COPY --chown=1000:0 repos.csv repos.csv
 
 CMD ["./publish.sh", "repos.csv"]

--- a/README.md
+++ b/README.md
@@ -191,6 +191,14 @@ For private repositories, credentials are mounted at runtime (never baked into i
 
 See each stage's README for specific mounting instructions.
 
+### Non-root user
+
+Both Dockerfiles produce images that run as a dedicated non-root user (`moderne`, UID 1000, GID 0), so no extra configuration is needed to satisfy policies that forbid root containers (for example Kubernetes `runAsNonRoot: true` pod security settings). CLI configuration and credentials live in `/home/moderne`, and the writable directories (`/home/moderne`, `/var/moderne`, `/app`) are group-writable by GID 0 so the images also work on platforms that assign an arbitrary UID at runtime (such as OpenShift).
+
+Two practical consequences:
+- Host directories bind-mounted at `/var/moderne` must be writable by UID 1000 (pre-create them as your regular user rather than letting Docker create them as root).
+- Credential files mounted into `/home/moderne` must be readable by UID 1000.
+
 ### Repository list format
 The `repos.csv` file columns:
 - `cloneUrl` (required) - Full git clone URL
@@ -404,7 +412,7 @@ Generated: 2025-01-20 14:32 UTC
 [PASS] PUBLISH_URL: https://artifactory.company.com/moderne
 [PASS] Publish credentials: PUBLISH_USER/PASSWORD set
        Git credentials:
-[PASS] HTTPS credentials: /root/.git-credentials (2 entries)
+[PASS] HTTPS credentials: /home/moderne/.git-credentials (2 entries)
 
 === repos.csv ===
 [PASS] File: /app/repos.csv (exists)
@@ -449,7 +457,7 @@ Generated: 2025-01-20 14:32 UTC
 [PASS] PUBLISH_URL: parallel throughput 42ms/request
 
 === Maven repositories ===
-       Using: /root/.m2/settings.xml
+       Using: /home/moderne/.m2/settings.xml
        Testing central (10 sequential requests)...
        Sequential: min=38ms avg=42ms max=67ms
 [PASS] central: average latency 42ms

--- a/diagnostics/checks/auth-scm.sh
+++ b/diagnostics/checks/auth-scm.sh
@@ -47,7 +47,7 @@ if [[ -n "$GIT_CREDS_FILE" ]]; then
         detect_container
         if [[ "$IN_CONTAINER" == true ]]; then
             info "In container, mount the file as read-only:"
-            info "  -v /path/.git-credentials:/root/.git-credentials:ro"
+            info "  -v /path/.git-credentials:/home/moderne/.git-credentials:ro"
         else
             info "Consider: chmod 400 ~/.git-credentials"
         fi

--- a/publish.sh
+++ b/publish.sh
@@ -159,13 +159,13 @@ configure_credentials() {
   fi
 
   if [ -n "${GIT_CREDENTIALS:-}" ]; then
-    echo -e "${GIT_CREDENTIALS}" > /root/.git-credentials
+    echo -e "${GIT_CREDENTIALS}" > "$HOME/.git-credentials"
   fi
 
   if [ -n "${GIT_SSH_CREDENTIALS:-}" ]; then
-    mkdir -p /root/.ssh
-    echo -e "${GIT_SSH_CREDENTIALS}" > /root/.ssh/private-key
-    chmod 600 /root/.ssh/private-key
+    mkdir -p "$HOME/.ssh"
+    echo -e "${GIT_SSH_CREDENTIALS}" > "$HOME/.ssh/private-key"
+    chmod 600 "$HOME/.ssh/private-key"
   fi
 
   # Configure artifact repository


### PR DESCRIPTION
## Background / problem
Most mass-ingest customers are financial institutions whose container platforms forbid running as root. Both example Dockerfiles ran everything as root and kept all state under `/root`, so every one of these customers had to restructure the image themselves before they could deploy it. This came up repeatedly during onboarding and each customer solved it slightly differently.

## Solution
Both images now create a dedicated `moderne` user (UID 1000, primary group 0) and drop privileges before any Moderne CLI configuration runs, so the container runs as non-root out of the box. System-level installation (packages, JDKs, Gradle and Maven, certificate imports) still happens as root in earlier layers, and a new CLI CONFIGURATION section groups everything that must run as the runtime user so that CLI state lands in `/home/moderne`. The numeric `USER 1000` lets Kubernetes verify `runAsNonRoot: true` without extra pod configuration, and group-0 ownership with group-writable directories keeps the images working on platforms that assign an arbitrary UID at runtime, such as OpenShift.

`publish.sh` now writes git and SSH credentials to `$HOME` instead of `/root`, the diagnostics keep their old `/root` lookups as fallbacks for older images, and the READMEs and compose file mount credentials into `/home/moderne`. The main README documents the two practical consequences: bind-mounted data directories must be writable by UID 1000, and mounted credential files must be readable by UID 1000.

## Test plan
- [x] Built both images and confirmed containers run as `uid=1000(moderne)` with the Moderne CLI baked into `/home/moderne/.moderne`
- [x] `publish.sh` writes git/SSH credentials (key mode 600) and `/var/moderne` data as non-root
- [x] Read-only mounted `.git-credentials` resolves through `git credential fill`
- [x] Diagnostics mode (`DIAGNOSE=true`) runs cleanly as non-root
- [x] Arbitrary-UID run (`--user 100012:0`, no passwd entry) works end to end, including running the Moderne CLI
