### PR TITLE
Prevent git from erasing credentials when a server rejects them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -249,8 +249,12 @@ FROM language-support AS runner
 
 # Git authentication configuration
 # Git credentials are configured at runtime via volume mounts to avoid baking secrets into the image.
-# Configure git to use the credential store that will be mounted at runtime
-RUN git config --global credential.helper "store --file=/root/.git-credentials"
+# The helper only implements "get": when a server rejects a credential (HTTP 401), git asks its
+# helpers to erase it, and the standard store helper would wipe the /root/.git-credentials entry
+# for that whole host, breaking every remaining repository in the run. The trade-off is that a
+# revoked token keeps being offered (and rejected) once per remaining repository on that host,
+# which may count toward the SCM's failed-authentication lockout policy for the account.
+RUN git config --global credential.helper '!f() { if [ "$1" = "get" ]; then git credential-store --file=/root/.git-credentials get; fi; }; f'
 # Optionally disable SSL verification if needed
 # RUN git config --global http.sslVerify false
 

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -320,8 +320,12 @@ FROM language-support AS runner
 
 # Git authentication configuration
 # Git credentials are configured at runtime via volume mounts to avoid baking secrets into the image.
-# Configure git to use the credential store that will be mounted at runtime
-RUN git config --global credential.helper "store --file=/root/.git-credentials"
+# The helper only implements "get": when a server rejects a credential (HTTP 401), git asks its
+# helpers to erase it, and the standard store helper would wipe the /root/.git-credentials entry
+# for that whole host, breaking every remaining repository in the run. The trade-off is that a
+# revoked token keeps being offered (and rejected) once per remaining repository on that host,
+# which may count toward the SCM's failed-authentication lockout policy for the account.
+RUN git config --global credential.helper '!f() { if [ "$1" = "get" ]; then git credential-store --file=/root/.git-credentials get; fi; }; f'
 # Optionally disable SSL verification if needed
 # RUN git config --global http.sslVerify false
 

--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ Generated: 2025-01-20 14:32 UTC
 
 === SCM credentials ===
 [PASS] .git-credentials: found 2 credential(s)
-[PASS] .git-credentials: file is read-only (mode 400)
+[PASS] credential.helper: get-only wrapper (erase requests ignored)
 
 === Publish latency ===
        Testing PUBLISH_URL (10 sequential requests)...

--- a/diagnostics/checks/auth-scm.sh
+++ b/diagnostics/checks/auth-scm.sh
@@ -3,7 +3,7 @@
 #
 # Validates the .git-credentials file for common issues:
 # - File exists and contains credentials
-# - File permissions (read-only recommended)
+# - Credential helper cannot erase the file on auth failure
 # - URL encoding issues in passwords
 #
 # Note: Actual SCM connectivity is tested by scm-repos.sh
@@ -35,25 +35,7 @@ if [[ -n "$GIT_CREDS_FILE" ]]; then
         pass ".git-credentials: found $CRED_LINES credential(s)"
     fi
 
-    # Check 2: Is file read-only? Git can wipe it on auth failure
-    # Note: -w always returns true for root, so check actual permissions
-    FILE_PERMS=$(stat -c '%a' "$GIT_CREDS_FILE" 2>/dev/null || stat -f '%Lp' "$GIT_CREDS_FILE" 2>/dev/null)
-    if [[ "$FILE_PERMS" =~ ^(400|440|444|000)$ ]]; then
-        pass ".git-credentials: file is read-only (mode $FILE_PERMS)"
-    else
-        warn ".git-credentials: file is writable (mode $FILE_PERMS)"
-        info "Git may clear credentials on authentication failure"
-        # Detect container and suggest appropriate fix (detect_container from core.sh)
-        detect_container
-        if [[ "$IN_CONTAINER" == true ]]; then
-            info "In container, mount the file as read-only:"
-            info "  -v /path/.git-credentials:/root/.git-credentials:ro"
-        else
-            info "Consider: chmod 400 ~/.git-credentials"
-        fi
-    fi
-
-    # Check 3: Do credentials contain characters that need URL escaping?
+    # Check 2: Do credentials contain characters that need URL escaping?
     # Common issue: Bitbucket PATs contain '/' which must be encoded as %2F
     NEEDS_ESCAPE=false
     while IFS= read -r line; do
@@ -94,4 +76,53 @@ if [[ -n "$GIT_CREDS_FILE" ]]; then
     fi
 else
     info ".git-credentials: file not found (may use other auth method)"
+fi
+
+# Credential helper check: can git erase the credentials on auth failure?
+# When a server rejects a credential (HTTP 401), git asks every configured helper to
+# erase it; a store helper then wipes the file's entry for that whole host, failing
+# every remaining repository on that host. A get-only helper ignores erase requests.
+# File permissions do not protect against this: store replaces the file via rename,
+# so only directory writability matters. This check runs even when the credentials
+# file does not exist yet (publish.sh writes it from GIT_CREDENTIALS after startup
+# diagnostics have already run).
+CRED_PATH="${GIT_CREDS_FILE:-$HOME/.git-credentials}"
+case "$CRED_PATH" in
+    /*) ;;
+    *) CRED_PATH="$(cd "$(dirname "$CRED_PATH")" && pwd)/$(basename "$CRED_PATH")" ;;
+esac
+# An empty helper entry resets the list accumulated so far, so only entries after the
+# last empty one are active.
+GIT_HELPERS=$(git config --get-all credential.helper 2>/dev/null | awk '{ if ($0 == "") out = ""; else out = out $0 "\n" } END { printf "%s", out }')
+HELPER_SAFE=false
+HELPER_UNSAFE=false
+while IFS= read -r helper; do
+    [[ -z "$helper" ]] && continue
+    if [[ "$helper" == *'if [ "$1" = "get" ]'* ]]; then
+        HELPER_SAFE=true
+    elif [[ "$helper" == store* || "$helper" == *credential-store* ]]; then
+        HELPER_UNSAFE=true
+    fi
+done <<< "$GIT_HELPERS"
+detect_container
+if [[ "$HELPER_UNSAFE" == true ]]; then
+    if [[ "$IN_CONTAINER" == true ]]; then
+        warn "credential.helper: a store helper is active, git erases credentials on auth failure"
+        info "One rejected clone (HTTP 401) wipes the host's entry from $CRED_PATH,"
+        info "failing every remaining repository on that host. Configure a get-only helper instead:"
+        info "  git config --global --replace-all credential.helper '!f() { if [ \"\$1\" = \"get\" ]; then git credential-store --file=$CRED_PATH get; fi; }; f'"
+    else
+        info "credential.helper: a store helper is active; a rejected clone (HTTP 401) erases that host's entry from $CRED_PATH"
+        info "This is normal on a workstation; the mass-ingest container image configures a get-only helper instead"
+    fi
+elif [[ "$HELPER_SAFE" == true ]]; then
+    pass "credential.helper: get-only wrapper (erase requests ignored)"
+elif [[ -z "$GIT_HELPERS" ]]; then
+    if [[ "$IN_CONTAINER" == true ]]; then
+        warn "credential.helper: not configured, git will not read $CRED_PATH"
+    else
+        info "credential.helper: not configured"
+    fi
+else
+    info "credential.helper: custom helper configured (not validated)"
 fi


### PR DESCRIPTION
## Problem

When a clone receives an HTTP 401 (an expired or revoked token, or a repository the service account is not authorized for even though the token works for the rest of the host), git asks its configured credential helpers to erase the rejected credential. The `store` helper used by the mass-ingest images then rewrites `/root/.git-credentials` and removes the entry for the whole host. From that point on, every remaining repository on that host fails with `could not read Username for '...': terminal prompts disabled`, so a single rejected clone can break the rest of a long ingest run. Mounting the credentials file read-only does not protect the `GIT_CREDENTIALS` flow, since `publish.sh` copies the variable into a writable file at startup and git erases that copy.

## Solution

Configure a read-only credential helper that only implements the `get` action, so git's `erase` (and `store`) requests are no-ops and the credentials survive rejected clones. Applied to both `Dockerfile` and `Dockerfile.fips`. The trade-off, documented in the Dockerfiles, is that a revoked token keeps being offered once per remaining repository on that host instead of failing fast.

The diagnostics credential check is reworked to match: file permissions never protected against the erase (the `store` helper replaces the file via rename, so only directory writability matters), so the check now classifies the active credential helpers instead, distinguishes container from workstation runs, and runs even before `publish.sh` has written the credentials file from `GIT_CREDENTIALS`.

Verified against a local always-401 git server: with the `store` helper the first rejected clone empties the credentials file and all subsequent clones on the host fail; with the get-only helper the file is intact, later repositories still authenticate, and successful clones are unaffected. The helper string is POSIX sh and was tested under dash, bash, and busybox ash.
