### PR TITLE
Parameterize Gradle and Maven download URLs in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,11 @@ RUN mkdir -p /root/.moderne/cli/dist && \
 
 FROM modcli AS language-support
 
+# Artifact locations - override these to point at internal mirrors
+# (e.g. --build-arg GRADLE_DIST_URL=https://artifactory.internal/artifactory/data-local/gradle)
+ARG GRADLE_DIST_URL=https://services.gradle.org/distributions
+ARG MAVEN_REPO_URL=https://repo1.maven.org/maven2
+
 # Gradle (comment if projects don't use Gradle without a wrapper)
 # Install one or more Gradle versions for repos that lack a Gradle wrapper.
 # To add versions for repos with older build scripts, add them to GRADLE_EXTRA_VERSIONS (comma-separated).
@@ -114,11 +119,11 @@ FROM modcli AS language-support
 ARG GRADLE_VERSION=8.14
 ARG GRADLE_EXTRA_VERSIONS=
 RUN mkdir -p /opt/gradle && \
-    wget --no-check-certificate https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip && \
+    wget --no-check-certificate ${GRADLE_DIST_URL}/gradle-${GRADLE_VERSION}-bin.zip -O gradle-${GRADLE_VERSION}-bin.zip && \
     unzip -d /opt/gradle gradle-${GRADLE_VERSION}-bin.zip && \
     rm gradle-${GRADLE_VERSION}-bin.zip && \
     for v in $(echo "${GRADLE_EXTRA_VERSIONS}" | tr ',' ' '); do \
-        wget --no-check-certificate https://services.gradle.org/distributions/gradle-${v}-bin.zip && \
+        wget --no-check-certificate ${GRADLE_DIST_URL}/gradle-${v}-bin.zip -O gradle-${v}-bin.zip && \
         unzip -d /opt/gradle gradle-${v}-bin.zip && \
         rm gradle-${v}-bin.zip; \
     done
@@ -129,8 +134,9 @@ ENV PATH="${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin"
 
 # Maven (comment if projects don't use Maven without a wrapper)
 # NOTE: This version may be out of date as new versions are continually released. Check here for the latest version: https://repo1.maven.org/maven2/org/apache/maven/apache-maven/
-ENV MAVEN_VERSION=3.9.11
-RUN wget --no-check-certificate https://repo1.maven.org/maven2/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz && tar xzvf apache-maven-${MAVEN_VERSION}-bin.tar.gz && rm apache-maven-${MAVEN_VERSION}-bin.tar.gz
+ARG MAVEN_VERSION=3.9.11
+ENV MAVEN_VERSION=${MAVEN_VERSION}
+RUN wget --no-check-certificate ${MAVEN_REPO_URL}/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz -O apache-maven-${MAVEN_VERSION}-bin.tar.gz && tar xzvf apache-maven-${MAVEN_VERSION}-bin.tar.gz && rm apache-maven-${MAVEN_VERSION}-bin.tar.gz
 RUN mv apache-maven-${MAVEN_VERSION} /opt/apache-maven-${MAVEN_VERSION}
 RUN ln -s /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,11 +119,11 @@ ARG MAVEN_REPO_URL=https://repo1.maven.org/maven2
 ARG GRADLE_VERSION=8.14
 ARG GRADLE_EXTRA_VERSIONS=
 RUN mkdir -p /opt/gradle && \
-    wget --no-check-certificate ${GRADLE_DIST_URL}/gradle-${GRADLE_VERSION}-bin.zip -O gradle-${GRADLE_VERSION}-bin.zip && \
+    wget --no-check-certificate "${GRADLE_DIST_URL}/gradle-${GRADLE_VERSION}-bin.zip" -O gradle-${GRADLE_VERSION}-bin.zip && \
     unzip -d /opt/gradle gradle-${GRADLE_VERSION}-bin.zip && \
     rm gradle-${GRADLE_VERSION}-bin.zip && \
     for v in $(echo "${GRADLE_EXTRA_VERSIONS}" | tr ',' ' '); do \
-        wget --no-check-certificate ${GRADLE_DIST_URL}/gradle-${v}-bin.zip -O gradle-${v}-bin.zip && \
+        wget --no-check-certificate "${GRADLE_DIST_URL}/gradle-${v}-bin.zip" -O gradle-${v}-bin.zip && \
         unzip -d /opt/gradle gradle-${v}-bin.zip && \
         rm gradle-${v}-bin.zip; \
     done
@@ -136,7 +136,7 @@ ENV PATH="${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin"
 # NOTE: This version may be out of date as new versions are continually released. Check here for the latest version: https://repo1.maven.org/maven2/org/apache/maven/apache-maven/
 ARG MAVEN_VERSION=3.9.11
 ENV MAVEN_VERSION=${MAVEN_VERSION}
-RUN wget --no-check-certificate ${MAVEN_REPO_URL}/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz -O apache-maven-${MAVEN_VERSION}-bin.tar.gz && tar xzvf apache-maven-${MAVEN_VERSION}-bin.tar.gz && rm apache-maven-${MAVEN_VERSION}-bin.tar.gz
+RUN wget --no-check-certificate "${MAVEN_REPO_URL}/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz" -O apache-maven-${MAVEN_VERSION}-bin.tar.gz && tar xzvf apache-maven-${MAVEN_VERSION}-bin.tar.gz && rm apache-maven-${MAVEN_VERSION}-bin.tar.gz
 RUN mv apache-maven-${MAVEN_VERSION} /opt/apache-maven-${MAVEN_VERSION}
 RUN ln -s /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 

--- a/README.md
+++ b/README.md
@@ -224,10 +224,32 @@ See `dependency-repos.csv.example` for a template.
 ### Build arguments
 
 All Dockerfiles support:
-- `MODERNE_CLI_VERSION` - Specific CLI version (defaults to latest release)
-- `MODERNE_CLI_STAGE` - `release` (default) for latest release from Maven Central, `snapshot` for latest snapshot
-- `MODERNE_CLI_RELEASES_REPO` - Maven repository for release CLI artifacts (defaults to `https://repo1.maven.org/maven2`)
-- `MODERNE_CLI_SNAPSHOTS_REPO` - Maven repository for snapshot CLI artifacts (defaults to `https://central.sonatype.com/repository/maven-snapshots`)
+
+| Argument                     | Default                                                     | Description                                                       |
+|------------------------------|-------------------------------------------------------------|-------------------------------------------------------------------|
+| `MODERNE_CLI_VERSION`        | *(latest release)*                                          | Specific CLI version                                              |
+| `MODERNE_CLI_STAGE`          | `release`                                                   | `release` for latest release, `snapshot` for latest snapshot      |
+| `MODERNE_CLI_RELEASES_REPO`  | `https://repo1.maven.org/maven2`                            | Maven repository for release CLI artifacts                        |
+| `MODERNE_CLI_SNAPSHOTS_REPO` | `https://central.sonatype.com/repository/maven-snapshots`   | Maven repository for snapshot CLI artifacts                       |
+| `MAVEN_REPO_URL`             | `https://repo1.maven.org/maven2`                            | Maven repository the Maven distribution is downloaded from        |
+| `GRADLE_DIST_URL`            | `https://services.gradle.org/distributions`                 | Gradle distribution download URL                                  |
+| `GRADLE_VERSION`             | `8.14`                                                      | Primary Gradle version to install                                 |
+| `GRADLE_EXTRA_VERSIONS`      | *(empty)*                                                   | Comma-separated additional Gradle versions (e.g., `6.9.4,5.6.4`)  |
+| `MAVEN_VERSION`              | `3.9.11`                                                    | Maven version to install                                          |
+
+**Using internal mirrors:**
+
+In an egress-blocked environment, point every download at internal mirrors instead of editing the Dockerfile. The Gradle distributions and the Maven distribution come from `GRADLE_DIST_URL` and `MAVEN_REPO_URL`; the CLI itself comes from `MODERNE_CLI_RELEASES_REPO` (or `MODERNE_CLI_SNAPSHOTS_REPO`):
+
+```bash
+docker build \
+  --build-arg GRADLE_DIST_URL=https://artifactory.internal/artifactory/data-local/gradle \
+  --build-arg MAVEN_REPO_URL=https://artifactory.internal/artifactory/maven-central \
+  --build-arg MODERNE_CLI_RELEASES_REPO=https://artifactory.internal/artifactory/maven-central \
+  -t mass-ingest .
+```
+
+`GRADLE_DIST_URL` is used as `${GRADLE_DIST_URL}/gradle-<version>-bin.zip`, and `MAVEN_REPO_URL` as `${MAVEN_REPO_URL}/org/apache/maven/apache-maven/<version>/apache-maven-<version>-bin.tar.gz`, so the mirror must serve those layouts. The base images (`eclipse-temurin`, or `registry.access.redhat.com/ubi9/ubi` for FIPS) are pulled by the Docker daemon, so mirror those through your registry configuration rather than a build argument.
 
 ### FIPS-compliant image
 
@@ -238,15 +260,7 @@ A separate `Dockerfile.fips` is provided for environments that require FIPS 140-
 docker build -f Dockerfile.fips -t mass-ingest:fips .
 ```
 
-**Build arguments** (in addition to `MODERNE_CLI_VERSION`):
-
-| Argument             | Default                                      | Description                            |
-|----------------------|----------------------------------------------|----------------------------------------|
-| `MAVEN_REPO_URL`    | `https://repo1.maven.org/maven2`             | Maven repository for CLI and Maven     |
-| `GRADLE_DIST_URL`   | `https://services.gradle.org/distributions`  | Gradle distribution download URL       |
-| `GRADLE_VERSION`    | `8.14`                                       | Primary Gradle version to install      |
-| `GRADLE_EXTRA_VERSIONS` | *(empty)*                                | Comma-separated additional Gradle versions (e.g., `6.9.4,5.6.4`) |
-| `MAVEN_VERSION`     | `3.9.11`                                     | Maven version to install               |
+**Build arguments:** the same set as the standard image (see [Build arguments](#build-arguments) above).
 
 **Using internal mirrors:**
 


### PR DESCRIPTION
Updates the `Dockerfile` to be consistent with `Dockerfile.fips`, which already exposes `GRADLE_DIST_URL` and `MAVEN_REPO_URL` build args for pointing at internal mirrors. The regular `Dockerfile` hard-coded `services.gradle.org` and `repo1.maven.org`, so it had to be hand-edited in egress-blocked environments. Same arg names and defaults, so one `--build-arg` invocation now works against either file.

Also updates the README: the build arguments are now one table covering all Dockerfiles, with an internal-mirror example, and the FIPS section points at it instead of repeating a partial table.

Verified with full image builds, once with default args and once with both URLs pointed at a local mirror.
